### PR TITLE
Require faraday 0.9.x

### DIFF
--- a/active_rest_client.gemspec
+++ b/active_rest_client.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "oj", "=2.1.4" # 2.1.7 breaks under linux
   spec.add_runtime_dependency "activesupport"
-  spec.add_runtime_dependency "faraday"
+  spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "patron", ">= 0.4.9" # 0.4.18 breaks against Curl v0.7.15 but works with webmock
 end


### PR DESCRIPTION
I just want to say that I really like your work with this gem, and that I find it incredibly useful and well written. This pull request is in response to an issue I encountered while initially trying to implement the gem. The issue was an incompatibility with earlier versions of the gem "faraday".

In my project, the gem dependencies involving faraday were as follows:

```
koala (1.5.0)
  faraday (~> 0.7)
oauth2 (0.8.1)
  faraday (~> 0.8)
```

This left me running faraday (0.8.8). 

Below is an example of the model I created to test with:

``` ruby
class Employee < ActiveRestClient::Base
  base_url "https://api.mysite.com"

  get :find, "/employee/:id"
end
```

And this is the IO from my console:

```
[1] pry(main)> Employee.find(10167)
NoMethodError: undefined method `timeout=' for {}:Hash
from /Users/russell.cloak/.rvm/gems/ruby-1.9.3-p125@mysite/gems/active_rest_client-0.9.68/lib/active_rest_client/configuration.rb:86:in `block in default_faraday_config'
```

I looked into faraday and noticed I was a few versions behind (0.8.8 to 0.9.0), so I upgraded faraday locally and it worked perfectly. They added a module called `Options` which uses constructors that allow methods to be called - instead of simply using a Hash for them.

I then added this commit and used the local version of the active-rest-client gem, which also worked.

Please let me know if there is anything I failed to consider, and thanks again for your work on this gem.

Below is the commit's message:

Any version of faraday less than 0.9.0 (at least up to 0.8.8) has a
conflict with the default_faraday_config method in configuration.rb.

The issue was that faraday used to use a simple Hash to hold options,
which does not respond to the #timeout= method. It was replaced with
the Options module's #connection_config which handles configuration
in a much more sane manner.
