### PR TITLE
Remove explicit faraday version and use config / errors compatible with < 0.8

### DIFF
--- a/active_rest_client.gemspec
+++ b/active_rest_client.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "activesupport"
-  spec.add_runtime_dependency "faraday", "~> 0.9"
+  spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "patron", ">= 0.4.9" # 0.4.18 breaks against Curl v0.7.15 but works with webmock
 end

--- a/lib/active_rest_client/configuration.rb
+++ b/lib/active_rest_client/configuration.rb
@@ -103,8 +103,15 @@ module ActiveRestClient
       def default_faraday_config
         Proc.new do |faraday|
           faraday.adapter(adapter)
-          faraday.options.timeout       = 10
-          faraday.options.open_timeout  = 10
+
+          if faraday.options.respond_to?(:timeout=)
+            faraday.options.timeout         = 10
+            faraday.options.open_timeout    = 10
+          else
+            faraday.options['timeout']      = 10
+            faraday.options['open_timeout'] = 10
+          end
+
           faraday.headers['User-Agent'] = "ActiveRestClient/#{ActiveRestClient::VERSION}"
           faraday.headers['Connection'] = "Keep-Alive"
           faraday.headers['Accept']     = "application/json"

--- a/lib/active_rest_client/connection.rb
+++ b/lib/active_rest_client/connection.rb
@@ -23,13 +23,13 @@ module ActiveRestClient
 
     def make_safe_request(path, &block)
       block.call
-    rescue Faraday::TimeoutError
+    rescue Faraday::Error::TimeoutError
       raise ActiveRestClient::TimeoutException.new("Timed out getting #{full_url(path)}")
-    rescue Faraday::ConnectionFailed
+    rescue Faraday::Error::ConnectionFailed
       begin
         reconnect
         block.call
-      rescue Faraday::ConnectionFailed
+      rescue Faraday::Error::ConnectionFailed
         raise ActiveRestClient::ConnectionFailedException.new("Unable to connect to #{full_url(path)}")
       end
     end

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -99,7 +99,7 @@ describe ActiveRestClient::Connection do
   end
 
   it "should retry once in the event of a connection failed" do
-    stub_request(:get, "www.example.com/foo").to_raise(Faraday::ConnectionFailed.new("Foo"))
+    stub_request(:get, "www.example.com/foo").to_raise(Faraday::Error::ConnectionFailed.new("Foo"))
     expect { @connection.get("/foo") }.to raise_error(ActiveRestClient::ConnectionFailedException)
   end
 


### PR DESCRIPTION
This reverts 48bf42c47b8915d1484bd1419adb4261b9342298 and adds a switch based on whether Faraday options is a hash or options object. Additionally it uses the Faraday::Error class names which exist in Faraday 0.8 and 0.9.

This commit makes active-rest-client compatible with faraday versions 0.8 as well as 0.9+.
