### PR TITLE
Migrate to RSpec 3

### DIFF
--- a/active_rest_client.gemspec
+++ b/active_rest_client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 2"
+  spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "simplecov"

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -105,8 +105,8 @@ describe ActiveRestClient::Base do
 
   it 'should respond_to? attributes defined in the response' do
     client = EmptyExample.new(:hello => "World")
-    client.respond_to?(:hello).should be_true
-    client.respond_to?(:world).should be_false
+    client.respond_to?(:hello).should be_truthy
+    client.respond_to?(:world).should be_falsy
   end
 
   it "should save the base URL for the API server" do
@@ -236,7 +236,7 @@ describe ActiveRestClient::Base do
       begin
         response = OpenStruct.new(_status:200, body:"This is a non-JSON string")
         other_response = OpenStruct.new(_status:200, body:"This is another non-JSON string")
-        allow_any_instance_of(ActiveRestClient::Connection).to receive(:get) do |url, others|
+        allow_any_instance_of(ActiveRestClient::Connection).to receive(:get) do |connection, url, others|
           if url == "/?test=1"
             OpenStruct.new(status:200, headers:{}, body:response)
           else

--- a/spec/lib/caching_spec.rb
+++ b/spec/lib/caching_spec.rb
@@ -10,7 +10,7 @@ describe ActiveRestClient::Caching do
       class CachingExample1
         include ActiveRestClient::Caching
       end
-      expect(CachingExample1.perform_caching).to be_false
+      expect(CachingExample1.perform_caching).to be_falsy
     end
 
     it "should be able to have caching enabled without affecting ActiveRestClient::Base" do
@@ -18,19 +18,19 @@ describe ActiveRestClient::Caching do
         include ActiveRestClient::Caching
       end
       CachingExample2.perform_caching true
-      expect(CachingExample2.perform_caching).to be_true
-      expect(ActiveRestClient::Base.perform_caching).to be_false
+      expect(CachingExample2.perform_caching).to be_truthy
+      expect(ActiveRestClient::Base.perform_caching).to be_falsy
     end
 
     it "should be possible to enable caching for all objects" do
       class CachingExample3 < ActiveRestClient::Base ; end
       ActiveRestClient::Base._reset_caching!
 
-      expect(ActiveRestClient::Base.perform_caching).to be_false
+      expect(ActiveRestClient::Base.perform_caching).to be_falsy
 
       ActiveRestClient::Base.perform_caching = true
-      expect(ActiveRestClient::Base.perform_caching).to be_true
-      expect(CachingExample3.perform_caching).to be_true
+      expect(ActiveRestClient::Base.perform_caching).to be_truthy
+      expect(CachingExample3.perform_caching).to be_truthy
 
       ActiveRestClient::Base._reset_caching!
     end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -20,12 +20,12 @@ describe ActiveRestClient::Configuration do
     class UnusuedConfigurationExample1
       include ActiveRestClient::Configuration
     end
-    expect(UnusuedConfigurationExample1.whiny_missing).to be_false
+    expect(UnusuedConfigurationExample1.whiny_missing).to be_falsy
   end
 
   it "should allow whiny missing methods to be enabled" do
     ConfigurationExample.whiny_missing true
-    expect(ConfigurationExample.whiny_missing).to be_true
+    expect(ConfigurationExample.whiny_missing).to be_truthy
   end
 
   it "should remember the set base_url" do
@@ -73,7 +73,7 @@ describe ActiveRestClient::Configuration do
     class LazyLoadingConfigurationExample1
       include ActiveRestClient::Configuration
     end
-    expect(LazyLoadingConfigurationExample1.lazy_load?).to be_false
+    expect(LazyLoadingConfigurationExample1.lazy_load?).to be_falsy
   end
 
   it "should be able to switch on lazy loading" do
@@ -81,14 +81,14 @@ describe ActiveRestClient::Configuration do
       include ActiveRestClient::Configuration
       lazy_load!
     end
-    expect(LazyLoadingConfigurationExample2.lazy_load?).to be_true
+    expect(LazyLoadingConfigurationExample2.lazy_load?).to be_truthy
   end
 
   it "should default to non-verbose loggingg" do
     class VerboseConfigurationExample1
       include ActiveRestClient::Configuration
     end
-    expect(VerboseConfigurationExample1.verbose).to be_false
+    expect(VerboseConfigurationExample1.verbose).to be_falsy
   end
 
   it "should be able to switch on verbose logging" do
@@ -100,20 +100,18 @@ describe ActiveRestClient::Configuration do
       include ActiveRestClient::Configuration
       verbose true
     end
-    expect(VerboseConfigurationExample2.verbose).to be_true
-    expect(VerboseConfigurationExample3.verbose).to be_true
+    expect(VerboseConfigurationExample2.verbose).to be_truthy
+    expect(VerboseConfigurationExample3.verbose).to be_truthy
   end
 
   it "should store a translator given" do
-    expect{ ConfigurationExample.send(:translator) }.to_not raise_error
-    ConfigurationExample.send(:translator, String)
-    expect{ ConfigurationExample.translator.respond_to?(:length) }.to be_true
+    ConfigurationExample.translator(String)
+    expect(ConfigurationExample.translator).to eq String
   end
 
   it "should store a proxy given" do
-    expect{ ConfigurationExample.send(:proxy) }.to_not raise_error
-    ConfigurationExample.send(:proxy, String)
-    expect{ ConfigurationExample.proxy.respond_to?(:length) }.to be_true
+    ConfigurationExample.proxy(String)
+    expect(ConfigurationExample.proxy).to eq String
   end
 
   describe "faraday_config" do

--- a/spec/lib/instrumentation_spec.rb
+++ b/spec/lib/instrumentation_spec.rb
@@ -30,7 +30,7 @@ describe ActiveRestClient::Instrumentation do
       should_receive(:get).
       with("/real", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:200))
-    ActiveRestClient::Logger.should_receive(:debug).with {|*args| args.first[/ActiveRestClient.*ms\)/]}
+    ActiveRestClient::Logger.should_receive(:debug) {|*args| args.first[/ActiveRestClient.*ms\)/]}
     ActiveRestClient::Logger.should_receive(:debug).at_least(:once).with(any_args)
     InstrumentationExampleClient.real
   end

--- a/spec/lib/lazy_loader_spec.rb
+++ b/spec/lib/lazy_loader_spec.rb
@@ -19,7 +19,7 @@ describe ActiveRestClient::LazyLoader do
     request.should_receive(:call).and_return(response)
     response.should_receive(:valid).and_return(true)
     loader = ActiveRestClient::LazyLoader.new(request)
-    expect(loader.valid).to be_true
+    expect(loader.valid).to be_truthy
   end
 
 end

--- a/spec/lib/recording_spec.rb
+++ b/spec/lib/recording_spec.rb
@@ -5,11 +5,11 @@ describe ActiveRestClient::Recording do
     class MyObject1
       include ActiveRestClient::Recording
     end
-    expect(MyObject1.record_response?).to be_false
+    expect(MyObject1.record_response?).to be_falsy
     MyObject1.record_response do
       puts "Hello world"
     end
-    expect(MyObject1.record_response?).to be_true
+    expect(MyObject1.record_response?).to be_truthy
   end
 
   it "remembers a block given to it to later be called back" do

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -178,7 +178,7 @@ describe ActiveRestClient::Request do
 
   it "should log faked responses" do
     ActiveRestClient::Logger.stub(:debug)
-    ActiveRestClient::Logger.should_receive(:debug).with {|*args| args.first["Faked response found"]}
+    ActiveRestClient::Logger.should_receive(:debug) {|*args| args.first["Faked response found"]}
     ExampleClient.fake id:1234, debug:true
   end
 
@@ -222,8 +222,10 @@ describe ActiveRestClient::Request do
       should_receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:200))
-    ActiveRestClient::Logger.should_receive(:info).with {|*args| args.first[%r{Requesting http://www.example.com/create}]}
-    ActiveRestClient::Logger.should_receive(:debug).at_least(1).times.with {|*args| args.first[/Response received \d+ bytes/] || args.first["Trying to read from cache"]}
+    ActiveRestClient::Logger.should_receive(:info) {|*args| args.first[%r{Requesting http://www.example.com/create}]}
+    ActiveRestClient::Logger.should_receive(:debug).at_least(1).times do |*args|
+      args.first[/Response received \d+ bytes/] || args.first["Trying to read from cache"]
+    end
 
     object = ExampleClient.new(first_name:"John", should_disappear:true)
     object.create
@@ -236,8 +238,10 @@ describe ActiveRestClient::Request do
       should_receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:200))
-    ActiveRestClient::Logger.should_receive(:info).with {|*args| args.first[%r{Requesting http://www.example.com/create}]}
-    ActiveRestClient::Logger.should_receive(:debug).at_least(1).times.with {|*args| args.first[/Response received \d+ bytes/] || args.first["Trying to read from cache"]}
+    ActiveRestClient::Logger.should_receive(:info) {|*args| args.first[%r{Requesting http://www.example.com/create}]}
+    ActiveRestClient::Logger.should_receive(:debug).at_least(1).times do |*args|
+      args.first[/Response received \d+ bytes/] || args.first["Trying to read from cache"]
+    end
 
     object = ExampleClient.new(first_name:"John", should_disappear:true)
     object.create
@@ -536,17 +540,17 @@ describe ActiveRestClient::Request do
       fake_object = RequestFakeObject.new
       request = ActiveRestClient::Request.new(method, fake_object, {})
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => "application/hal+json"}))
-      expect(request.hal_response?).to be_true
+      expect(request.hal_response?).to be_truthy
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => "application/json"}))
-      expect(request.hal_response?).to be_true
+      expect(request.hal_response?).to be_truthy
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => "text/plain"}))
-      expect(request.hal_response?).to be_false
+      expect(request.hal_response?).to be_falsy
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => ["text/plain", "application/hal+json"]}))
-      expect(request.hal_response?).to be_true
+      expect(request.hal_response?).to be_truthy
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => ["text/plain", "application/json"]}))
-      expect(request.hal_response?).to be_true
+      expect(request.hal_response?).to be_truthy
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => ["text/plain"]}))
-      expect(request.hal_response?).to be_false
+      expect(request.hal_response?).to be_falsy
     end
 
     it "should map _links in to the normal attributes" do

--- a/spec/lib/result_iterator_spec.rb
+++ b/spec/lib/result_iterator_spec.rb
@@ -29,9 +29,9 @@ describe ActiveRestClient::ResultIterator do
 
   it "should implement any?" do
     result = ActiveRestClient::ResultIterator.new
-    expect(result.any?).to be_false
+    expect(result.any?).to be_falsy
     result << "a"
-    expect(result.any?).to be_true
+    expect(result.any?).to be_truthy
   end
 
   it "should implement items" do
@@ -64,10 +64,10 @@ describe ActiveRestClient::ResultIterator do
 
   it "should implement empty?" do
     result = ActiveRestClient::ResultIterator.new
-    expect(result.empty?).to be_true
+    expect(result.empty?).to be_truthy
     result << "a"
     result << "z"
-    expect(result.empty?).to be_false
+    expect(result.empty?).to be_falsy
   end
 
   it "should implement direct index access" do
@@ -83,7 +83,7 @@ describe ActiveRestClient::ResultIterator do
     100.times do |n|
       result << n
     end
-    expect(result.shuffle.first == result.shuffle.first && result.shuffle.first == result.shuffle.first).to_not be_true
+    expect(result.shuffle.first == result.shuffle.first && result.shuffle.first == result.shuffle.first).to be_falsy
   end
 
   it "can parallelise calls to each item" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,13 +16,19 @@ RSpec.configure do |config|
   config.color = true
   # config.formatter     = 'documentation'
 
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
+
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+
+  config.mock_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
 end
 
 class TestCacheStore


### PR DESCRIPTION
I was seeing deprecation warnings with 2.99 so I decided to move the project to 3. A proper migration would convert all `should` calls into `expect` but given the volume of tests I couldn't be bothered :)