### PR TITLE
Close #66 check response.body is present

### DIFF
--- a/lib/active_rest_client/request.rb
+++ b/lib/active_rest_client/request.rb
@@ -415,8 +415,10 @@ module ActiveRestClient
     def generate_new_object(options={})
       if @response.body.is_a?(Array) || @response.body.is_a?(Hash)
         body = @response.body
-      else
+      elsif @response.body.present?
         body = MultiJson.load(@response.body) || {}
+      else
+        body = {}
       end
       body = begin
         @method[:name].nil? ? body : translator.send(@method[:name], body)


### PR DESCRIPTION
if the response.body is missing the MultiJson.load fails with a
MultiJson::LoadError.