### PR TITLE
Added after_filter functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,9 +315,9 @@ ActiveRestClient::Base.cache_store = Redis::Store.new("redis://localhost:6379/0/
 
 ### Using filters
 
-You can use filters to alter get/post parameters, the URL or set the post body (doing so overrides normal parameter insertion in to the body) before a request.  This can either be a block or a named method (like ActionController's `before_filter`/`before_action` methods).
+You can use filters to alter get/post parameters, the URL or set the post body (doing so overrides normal parameter insertion in to the body) before a request or to adjust the response after a request.  This can either be a block or a named method (like ActionController's `before_filter`/`before_action` methods).
 
-The filter is passed the name of the method (e.g. `:save`) and a request object. The request object has four public attributes `post_params` (a Hash of the POST parameters), `get_params` (a Hash of the GET parameters), headers and `url` (a String containing the full URL without GET parameters appended)
+The filter is passed the name of the method (e.g. `:save`) and an object (a request object for `before_filter` and a response object for `after_filter`). The request object has four public attributes `post_params` (a Hash of the POST parameters), `get_params` (a Hash of the GET parameters), headers and `url` (a String containing the full URL without GET parameters appended)
 
 ```ruby
 require 'secure_random'
@@ -365,6 +365,22 @@ end
 
 class Person < MyProject::Base
   # No need to declare a before_request for :api_key, already defined by the parent
+end
+```
+
+After filters work in exactly the same way:
+
+```ruby
+class Person < ActiveRestClient::Base
+  after_filter :fix_empty_content
+
+  private
+
+  def fix_empty_content
+    if response.status == 204 && response.body.blank?
+      response.body = '{"empty": true}'
+    end
+  end
 end
 ```
 

--- a/lib/active_rest_client/request.rb
+++ b/lib/active_rest_client/request.rb
@@ -99,9 +99,9 @@ module ActiveRestClient
           return handle_response(OpenStruct.new(status:200, body:fake, headers:{"X-ARC-Faked-Response" => "true"}))
         end
         if object_is_class?
-          @object.send(:_filter_request, @method[:name], self)
+          @object.send(:_filter_request, :before, @method[:name], self)
         else
-          @object.class.send(:_filter_request, @method[:name], self)
+          @object.class.send(:_filter_request, :before, @method[:name], self)
         end
         append_get_parameters
         prepare_request_body
@@ -125,6 +125,11 @@ module ActiveRestClient
         end
         if object_is_class? && @object.record_response?
           @object.record_response(self.url, response)
+        end
+        if object_is_class?
+          @object.send(:_filter_request, :after, @method[:name], response)
+        else
+          @object.class.send(:_filter_request, :after, @method[:name], response)
         end
         result = handle_response(response, cached)
         original_object_class.write_cached_response(self, response, result)

--- a/lib/active_rest_client/request_filtering.rb
+++ b/lib/active_rest_client/request_filtering.rb
@@ -2,35 +2,45 @@ module ActiveRestClient
   module RequestFiltering
     module ClassMethods
       def before_request(method_name = nil, &block)
-        @filters ||= []
+        @before_filters ||= []
         if block
-          @filters << block
+          @before_filters << block
         elsif method_name
-          @filters << method_name
+          @before_filters << method_name
         end
       end
 
-      def _filter_request(name, request)
-        _handle_super_class_filters(name, request)
-        @filters ||= []
-        @filters.each do |filter|
+      def after_request(method_name = nil, &block)
+        @after_filters ||= []
+        if block
+          @after_filters << block
+        elsif method_name
+          @after_filters << method_name
+        end
+      end
+
+      def _filter_request(type, name, param)
+        _handle_super_class_filters(type, name, param)
+        filters = (type == :before ? @before_filters : @after_filters)
+        filters ||= []
+        filters.each do |filter|
           if filter.is_a? Symbol
             if self.respond_to?(filter)
-              self.send(filter, name, request)
+              self.send(filter, name, param)
             else
               instance = self.new
-              instance.send(filter, name, request)
+              instance.send(filter, name, param)
             end
           else
-            filter.call(name, request)
+            filter.call(name, param)
           end
         end
       end
 
-      def _handle_super_class_filters(name, request)
+      def _handle_super_class_filters(type, name, request)
         @parents ||= []
         @parents.each do |parent|
-          parent._filter_request(name, request)
+          parent._filter_request(type, name, request)
         end
       end
 

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -204,7 +204,7 @@ describe ActiveRestClient::Base do
 
     it "runs filters as usual" do
       ActiveRestClient::Request.any_instance.should_receive(:do_request).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
-      EmptyExample.should_receive(:_filter_request).with(any_args)
+      EmptyExample.should_receive(:_filter_request).with(any_args).exactly(2).times
       EmptyExample._request("http://api.example.com/")
     end
 

--- a/spec/lib/request_filtering_spec.rb
+++ b/spec/lib/request_filtering_spec.rb
@@ -18,6 +18,8 @@ class RequestFilteringExample
   before_request :set_to_ssl
   before_request :set_via_instance
 
+  after_request :change_body
+
   private
 
   def self.set_to_ssl(name, request)
@@ -26,6 +28,10 @@ class RequestFilteringExample
 
   def set_via_instance(name, request)
     request.url.gsub!("//www", "//new")
+  end
+
+  def change_body(name, response)
+    response.body = "{test: 1}"
   end
 end
 
@@ -37,36 +43,42 @@ end
 
 describe ActiveRestClient::RequestFiltering do
   let(:request) { OpenStruct.new(get_params:{}, post_params:{}, url:"http://www.example.com", headers:ActiveRestClient::HeadersList.new) }
+  let(:response) { OpenStruct.new(body:"") }
 
   it "should call through to adjust the parameters" do
-    RequestFilteringExample._filter_request(:test, request)
+    RequestFilteringExample._filter_request(:before, :test, request)
     expect(request.get_params).to have_key(:filter1)
   end
 
   it "should call through for more than one filter" do
-    RequestFilteringExample._filter_request(:test, request)
+    RequestFilteringExample._filter_request(:before, :test, request)
     expect(request.get_params).to have_key(:filter1)
     expect(request.post_params).to have_key(:post_filter1)
   end
 
   it "should allow adjusting the URL via a named filter" do
-    RequestFilteringExample._filter_request(:test, request)
+    RequestFilteringExample._filter_request(:before, :test, request)
     expect(request.url).to match(/https:\/\//)
   end
 
   it "should allow adjusting the URL via a named filter as an instance method" do
-    RequestFilteringExample._filter_request(:test, request)
+    RequestFilteringExample._filter_request(:before, :test, request)
     expect(request.url).to match(/\/\/new\./)
   end
 
   it "should allow filters to be set on the parent or on the child" do
-    SubClassedRequestFilteringExample._filter_request(:test, request)
+    SubClassedRequestFilteringExample._filter_request(:before, :test, request)
     expect(request.url).to match(/\/\/new\./)
     expect(request.get_params[:api_key]).to eq(1234)
   end
 
   it "should allow filters to add custom headers" do
-    RequestFilteringExample._filter_request(:test, request)
+    RequestFilteringExample._filter_request(:before, :test, request)
     expect(request.headers["X-My-Header"]).to eq("myvalue")
+  end
+
+  it "should be able to alter the response body" do
+    RequestFilteringExample._filter_request(:after, :test, response)
+    expect(response.body).to eq("{test: 1}")
   end
 end


### PR DESCRIPTION
In response to a StackOverflow question (https://stackoverflow.com/questions/27573656/activerestclient-respond-to-204-no-content?sem=2) and issue #66, I've added the ability to have after_filter blocks as well as before_filter.  I've added tests and updated documentation.

I would have just committed it myself, but my access seems to have been removed again.  If I'd known that I likely wouldn't have made the patch (I'm not actively using this project any more, and if my access to just commit/push is removed then it reduces my inclination to contribute even further).

Anyway, here's the PR, do as you wish with it...