### PR TITLE
Close #71 - Error when using a proxy and caching

### DIFF
--- a/lib/active_rest_client/proxy_base.rb
+++ b/lib/active_rest_client/proxy_base.rb
@@ -69,8 +69,9 @@ module ActiveRestClient
       def translate(result, options = {})
         result.headers["content-type"] = "application/hal+json"
         result = OpenStruct.new(status:result.status, headers:result.headers, body:result.body)
-        obj = MultiJson.load(result.body)
-        result.body = yield obj
+        if result.body.present?
+          result.body = yield MultiJson.load(result.body)
+        end
         result
       end
 

--- a/lib/active_rest_client/request.rb
+++ b/lib/active_rest_client/request.rb
@@ -422,7 +422,7 @@ module ActiveRestClient
       if @response.body.is_a?(Array) || @response.body.is_a?(Hash)
         body = @response.body
       else
-        body = MultiJson.load(@response.body) || {}
+        body = @response.body.blank? ? {} : MultiJson.load(@response.body)
       end
       body = begin
         @method[:name].nil? ? body : translator.send(@method[:name], body)

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -120,6 +120,13 @@ describe ActiveRestClient::Base do
     expect(ret.first_name).to eq("Billy")
   end
 
+  it 'skips the altering of the response body when there is none' do
+    allow_any_instance_of(ActiveRestClient::Connection).to receive(:get).with('/change-format', instance_of(Hash))
+      .and_return(double(body: '', status: 200, headers: {}))
+    result = ProxyClientExample.change_format
+    expect(result._attributes).to be_empty
+  end
+
   it "can continue with the request in the normal way, passing it on to the server" do
     ActiveRestClient::Connection.any_instance.should_receive(:get).with("/not_proxied?id=1", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
     ProxyClientExample.not_proxied(id:1)


### PR DESCRIPTION
An empty response body such as one that might be the result of a 304
response shouldn't cause an exception, it shouldn't be parsed as JSON at
all.