### PR TITLE
Convert specs to RSpec 2.99.2 syntax with Transpec

### DIFF
--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -39,7 +39,7 @@ end
 
 describe ActiveRestClient::Base do
   it 'should instantiate a new descendant' do
-    expect{EmptyExample.new}.to_not raise_error(Exception)
+    expect{EmptyExample.new}.to_not raise_error
   end
 
   it "should not instantiate a new base class" do
@@ -105,8 +105,8 @@ describe ActiveRestClient::Base do
 
   it 'should respond_to? attributes defined in the response' do
     client = EmptyExample.new(:hello => "World")
-    client.respond_to?(:hello).should be_true
-    client.respond_to?(:world).should be_false
+    expect(client.respond_to?(:hello)).to be_truthy
+    expect(client.respond_to?(:world)).to be_falsey
   end
 
   it "should save the base URL for the API server" do
@@ -149,14 +149,14 @@ describe ActiveRestClient::Base do
   end
 
   it "should be able to lazy instantiate an object from a prefixed lazy_ method call" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with('/find/1', anything).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with('/find/1', anything).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
     example = AlteringClientExample.lazy_find(1)
     expect(example).to be_an_instance_of(ActiveRestClient::LazyLoader)
     expect(example.first_name).to eq("Billy")
   end
 
   it "should be able to lazy instantiate an object from a prefixed lazy_ method call from an instance" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with('/find/1', anything).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with('/find/1', anything).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
     example = AlteringClientExample.new.lazy_find(1)
     expect(example).to be_an_instance_of(ActiveRestClient::LazyLoader)
     expect(example.first_name).to eq("Billy")
@@ -164,7 +164,7 @@ describe ActiveRestClient::Base do
 
   context "accepts a Translator to reformat JSON" do
     it "should log a deprecation warning when using a translator" do
-      ActiveRestClient::Logger.should_receive(:warn) do |message|
+      expect(ActiveRestClient::Logger).to receive(:warn) do |message|
         expect(message).to start_with("DEPRECATION")
       end
       Proc.new do
@@ -175,7 +175,7 @@ describe ActiveRestClient::Base do
     end
 
     it "should call Translator#method when calling the mapped method if it responds to it" do
-      TranslatorExample.should_receive(:all).with(an_instance_of(Hash)).and_return({})
+      expect(TranslatorExample).to receive(:all).with(an_instance_of(Hash)).and_return({})
       AlteringClientExample.all
     end
 
@@ -198,35 +198,35 @@ describe ActiveRestClient::Base do
 
   context "directly call a URL, rather than via a mapped method" do
     it "should be able to directly call a URL" do
-      ActiveRestClient::Request.any_instance.should_receive(:do_request).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
+      expect_any_instance_of(ActiveRestClient::Request).to receive(:do_request).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
       EmptyExample._request("http://api.example.com/")
     end
 
     it "runs filters as usual" do
-      ActiveRestClient::Request.any_instance.should_receive(:do_request).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
-      EmptyExample.should_receive(:_filter_request).with(any_args).exactly(2).times
+      expect_any_instance_of(ActiveRestClient::Request).to receive(:do_request).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
+      expect(EmptyExample).to receive(:_filter_request).with(any_args).exactly(2).times
       EmptyExample._request("http://api.example.com/")
     end
 
     it "should make an HTTP request" do
-      ActiveRestClient::Connection.any_instance.should_receive(:get).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
       EmptyExample._request("http://api.example.com/")
     end
 
     it "should make an HTTP request including the path in the base_url" do
-      ActiveRestClient::Connection.any_instance.should_receive(:get).with('/v1/all', anything).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with('/v1/all', anything).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
       NonHostnameBaseUrlExample.all
     end
 
     it "should map the response from the directly called URL in the normal way" do
-      ActiveRestClient::Request.any_instance.should_receive(:do_request).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
+      expect_any_instance_of(ActiveRestClient::Request).to receive(:do_request).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
       example = EmptyExample._request("http://api.example.com/")
       expect(example.first_name).to eq("Billy")
     end
 
     it "should be able to pass the plain response from the directly called URL bypassing JSON loading" do
       response = OpenStruct.new(_status:200, body:"This is another non-JSON string")
-      ActiveRestClient::Connection.any_instance.should_receive(:post).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:response))
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:post).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:response))
       expect(EmptyExample._plain_request("http://api.example.com/", :post, {id:1234})).to eq(response)
     end
 
@@ -236,7 +236,7 @@ describe ActiveRestClient::Base do
       begin
         response = OpenStruct.new(_status:200, body:"This is a non-JSON string")
         other_response = OpenStruct.new(_status:200, body:"This is another non-JSON string")
-        allow_any_instance_of(ActiveRestClient::Connection).to receive(:get) do |url, others|
+        allow_any_instance_of(ActiveRestClient::Connection).to receive(:get) do |instance, url, others|
           if url == "/?test=1"
             OpenStruct.new(status:200, headers:{}, body:response)
           else
@@ -254,19 +254,19 @@ describe ActiveRestClient::Base do
     end
 
     it "should be able to lazy load a direct URL request" do
-      ActiveRestClient::Request.any_instance.should_receive(:do_request).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
+      expect_any_instance_of(ActiveRestClient::Request).to receive(:do_request).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
       example = EmptyExample._lazy_request("http://api.example.com/")
       expect(example).to be_an_instance_of(ActiveRestClient::LazyLoader)
       expect(example.first_name).to eq("Billy")
     end
 
     it "should be able to specify a method and parameters for the call" do
-      ActiveRestClient::Connection.any_instance.should_receive(:post).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:post).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
       EmptyExample._request("http://api.example.com/", :post, {id:1234})
     end
 
     it "should be able to use mapped methods to create a request to pass in to _lazy_request" do
-      ActiveRestClient::Connection.any_instance.should_receive(:get).with('/find/1', anything).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with('/find/1', anything).and_return(OpenStruct.new(status:200, headers:{}, body:"{\"first_name\":\"Billy\"}"))
       request = AlteringClientExample._request_for(:find, :id => 1)
       example = AlteringClientExample._lazy_request(request)
       expect(example.first_name).to eq("Billy")
@@ -275,7 +275,7 @@ describe ActiveRestClient::Base do
 
   context "Recording a response" do
     it "calls back to the record_response callback with the url and response body" do
-      ActiveRestClient::Connection.any_instance.should_receive(:get).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"Hello world"))
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with(any_args).and_return(OpenStruct.new(status:200, headers:{}, body:"Hello world"))
       expect{RecordResponseExample.all}.to raise_error(Exception, "/all|Hello world")
     end
   end

--- a/spec/lib/caching_spec.rb
+++ b/spec/lib/caching_spec.rb
@@ -10,7 +10,7 @@ describe ActiveRestClient::Caching do
       class CachingExample1
         include ActiveRestClient::Caching
       end
-      expect(CachingExample1.perform_caching).to be_false
+      expect(CachingExample1.perform_caching).to be_falsey
     end
 
     it "should be able to have caching enabled without affecting ActiveRestClient::Base" do
@@ -18,19 +18,19 @@ describe ActiveRestClient::Caching do
         include ActiveRestClient::Caching
       end
       CachingExample2.perform_caching true
-      expect(CachingExample2.perform_caching).to be_true
-      expect(ActiveRestClient::Base.perform_caching).to be_false
+      expect(CachingExample2.perform_caching).to be_truthy
+      expect(ActiveRestClient::Base.perform_caching).to be_falsey
     end
 
     it "should be possible to enable caching for all objects" do
       class CachingExample3 < ActiveRestClient::Base ; end
       ActiveRestClient::Base._reset_caching!
 
-      expect(ActiveRestClient::Base.perform_caching).to be_false
+      expect(ActiveRestClient::Base.perform_caching).to be_falsey
 
       ActiveRestClient::Base.perform_caching = true
-      expect(ActiveRestClient::Base.perform_caching).to be_true
-      expect(CachingExample3.perform_caching).to be_true
+      expect(ActiveRestClient::Base.perform_caching).to be_truthy
+      expect(CachingExample3.perform_caching).to be_truthy
 
       ActiveRestClient::Base._reset_caching!
     end
@@ -110,8 +110,8 @@ describe ActiveRestClient::Caching do
         status:200,
         result:@cached_object,
         etag:@etag)
-      CachingExampleCacheStore5.any_instance.should_receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
-      ActiveRestClient::Connection.any_instance.should_receive(:get).with("/", hash_including("If-None-Match" => @etag)).and_return(OpenStruct.new(status:304, headers:{}))
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/", hash_including("If-None-Match" => @etag)).and_return(OpenStruct.new(status:304, headers:{}))
       ret = Person.all
       expect(ret.first_name).to eq("Johnny")
     end
@@ -139,8 +139,8 @@ describe ActiveRestClient::Caching do
         status:200,
         result:@cached_object,
         expires:Time.now + 30)
-      CachingExampleCacheStore5.any_instance.should_receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
-      ActiveRestClient::Connection.any_instance.should_not_receive(:get)
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
+      expect_any_instance_of(ActiveRestClient::Connection).not_to receive(:get)
       ret = Person.all
       expect(ret.first_name).to eq("Johnny")
     end
@@ -150,8 +150,8 @@ describe ActiveRestClient::Caching do
         status:200,
         result:@cached_object,
         expires:Time.now + 30)
-      CachingExampleCacheStore5.any_instance.should_receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
-      ActiveRestClient::Connection.any_instance.should_not_receive(:get)
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
+      expect_any_instance_of(ActiveRestClient::Connection).not_to receive(:get)
       p = Person.new(first_name:"Billy")
       ret = p.all({})
       expect(ret.first_name).to eq("Johnny")
@@ -168,32 +168,32 @@ describe ActiveRestClient::Caching do
         result:object,
         etag:@etag,
         expires:Time.now + 30)
-      CachingExampleCacheStore5.any_instance.should_receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
-      ActiveRestClient::Connection.any_instance.should_not_receive(:get)
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
+      expect_any_instance_of(ActiveRestClient::Connection).not_to receive(:get)
       ret = Person.all
       expect(ret.first.first_name).to eq("Johnny")
       expect(ret._status).to eq(200)
     end
 
     it "should not write the response to the cache unless if has caching headers" do
-      CachingExampleCacheStore5.any_instance.should_receive(:read).once.with("Person:/").and_return(nil)
-      CachingExampleCacheStore5.any_instance.should_not_receive(:write)
-      ActiveRestClient::Connection.any_instance.should_receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(status:200, body:"{\"result\":true}", headers:{}))
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(nil)
+      expect_any_instance_of(CachingExampleCacheStore5).not_to receive(:write)
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(status:200, body:"{\"result\":true}", headers:{}))
       ret = Person.all
     end
 
     it "should write the response to the cache if there's an etag" do
-      CachingExampleCacheStore5.any_instance.should_receive(:read).once.with("Person:/").and_return(nil)
-      CachingExampleCacheStore5.any_instance.should_receive(:write).once.with("Person:/", an_instance_of(String), {})
-      ActiveRestClient::Connection.any_instance.should_receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(status:200, body:"{\"result\":true}", headers:{etag:"1234567890"}))
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(nil)
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:write).once.with("Person:/", an_instance_of(String), {})
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(status:200, body:"{\"result\":true}", headers:{etag:"1234567890"}))
       Person.perform_caching true
       ret = Person.all
     end
 
     it "should write the response to the cache if there's a hard expiry" do
-      CachingExampleCacheStore5.any_instance.should_receive(:read).once.with("Person:/").and_return(nil)
-      CachingExampleCacheStore5.any_instance.should_receive(:write).once.with("Person:/", an_instance_of(String), an_instance_of(Hash))
-      ActiveRestClient::Connection.any_instance.should_receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(status:200, body:"{\"result\":true}", headers:{expires:(Time.now + 30).rfc822}))
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(nil)
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:write).once.with("Person:/", an_instance_of(String), an_instance_of(Hash))
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(status:200, body:"{\"result\":true}", headers:{expires:(Time.now + 30).rfc822}))
       Person.perform_caching = true
       ret = Person.all
     end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -20,12 +20,12 @@ describe ActiveRestClient::Configuration do
     class UnusuedConfigurationExample1
       include ActiveRestClient::Configuration
     end
-    expect(UnusuedConfigurationExample1.whiny_missing).to be_false
+    expect(UnusuedConfigurationExample1.whiny_missing).to be_falsey
   end
 
   it "should allow whiny missing methods to be enabled" do
     ConfigurationExample.whiny_missing true
-    expect(ConfigurationExample.whiny_missing).to be_true
+    expect(ConfigurationExample.whiny_missing).to be_truthy
   end
 
   it "should remember the set base_url" do
@@ -73,7 +73,7 @@ describe ActiveRestClient::Configuration do
     class LazyLoadingConfigurationExample1
       include ActiveRestClient::Configuration
     end
-    expect(LazyLoadingConfigurationExample1.lazy_load?).to be_false
+    expect(LazyLoadingConfigurationExample1.lazy_load?).to be_falsey
   end
 
   it "should be able to switch on lazy loading" do
@@ -81,14 +81,14 @@ describe ActiveRestClient::Configuration do
       include ActiveRestClient::Configuration
       lazy_load!
     end
-    expect(LazyLoadingConfigurationExample2.lazy_load?).to be_true
+    expect(LazyLoadingConfigurationExample2.lazy_load?).to be_truthy
   end
 
   it "should default to non-verbose loggingg" do
     class VerboseConfigurationExample1
       include ActiveRestClient::Configuration
     end
-    expect(VerboseConfigurationExample1.verbose).to be_false
+    expect(VerboseConfigurationExample1.verbose).to be_falsey
   end
 
   it "should be able to switch on verbose logging" do
@@ -100,34 +100,34 @@ describe ActiveRestClient::Configuration do
       include ActiveRestClient::Configuration
       verbose true
     end
-    expect(VerboseConfigurationExample2.verbose).to be_true
-    expect(VerboseConfigurationExample3.verbose).to be_true
+    expect(VerboseConfigurationExample2.verbose).to be_truthy
+    expect(VerboseConfigurationExample3.verbose).to be_truthy
   end
 
   it "should store a translator given" do
     expect{ ConfigurationExample.send(:translator) }.to_not raise_error
-    ConfigurationExample.send(:translator, String)
-    expect{ ConfigurationExample.translator.respond_to?(:length) }.to be_true
+    ConfigurationExample.send(:translator, String.new)
+    expect(ConfigurationExample.translator).to respond_to(:length)
   end
 
   it "should store a proxy given" do
     expect{ ConfigurationExample.send(:proxy) }.to_not raise_error
-    ConfigurationExample.send(:proxy, String)
-    expect{ ConfigurationExample.proxy.respond_to?(:length) }.to be_true
+    ConfigurationExample.send(:proxy, String.new)
+    expect(ConfigurationExample.proxy).to respond_to(:length)
   end
 
   describe "faraday_config" do
     let(:faraday_double){double(:faraday).as_null_object}
 
     it "should use default adapter if no other block set" do
-      faraday_double.should_receive(:adapter).with(:patron)
+      expect(faraday_double).to receive(:adapter).with(:patron)
       ConfigurationExample.faraday_config.call(faraday_double)
     end
 
     it "should us set adapter if no other block set" do
       ConfigurationExample.adapter = :net_http
 
-      faraday_double.should_receive(:adapter).with(:net_http)
+      expect(faraday_double).to receive(:adapter).with(:net_http)
 
       ConfigurationExample.faraday_config.call(faraday_double)
     end
@@ -135,7 +135,7 @@ describe ActiveRestClient::Configuration do
     it "should use the adapter of the passed in faraday_config block" do
       ConfigurationExample.faraday_config {|faraday| faraday.adapter(:rack)}
 
-      faraday_double.should_receive(:adapter).with(:rack)
+      expect(faraday_double).to receive(:adapter).with(:rack)
 
       ConfigurationExample.faraday_config.call(faraday_double)
     end

--- a/spec/lib/instrumentation_spec.rb
+++ b/spec/lib/instrumentation_spec.rb
@@ -9,29 +9,28 @@ end
 describe ActiveRestClient::Instrumentation do
   it "should save a load hook to include the instrumentation" do
     hook_tester = double("HookTester")
-    hook_tester.should_receive(:include).with(ActiveRestClient::ControllerInstrumentation)
+    expect(hook_tester).to receive(:include).with(ActiveRestClient::ControllerInstrumentation)
     ActiveSupport.run_load_hooks(:action_controller, hook_tester)
   end
 
   it "should call ActiveSupport::Notifications.instrument when making any request" do
-    ActiveSupport::Notifications.should_receive(:instrument).with("request_call.active_rest_client", {:name=>"InstrumentationExampleClient#fake"})
+    expect(ActiveSupport::Notifications).to receive(:instrument).with("request_call.active_rest_client", {:name=>"InstrumentationExampleClient#fake"})
     InstrumentationExampleClient.fake
   end
 
   it "should call ActiveSupport::Notifications#request_call when making any request" do
-    ActiveRestClient::Instrumentation.any_instance.should_receive(:request_call).with(an_instance_of(ActiveSupport::Notifications::Event))
+    expect_any_instance_of(ActiveRestClient::Instrumentation).to receive(:request_call).with(an_instance_of(ActiveSupport::Notifications::Event))
     InstrumentationExampleClient.fake
   end
 
 
   it "should log time spent in each API call" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:get).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:get).
       with("/real", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:200))
-    ActiveRestClient::Logger.should_receive(:debug).with {|*args| args.first[/ActiveRestClient.*ms\)/]}
-    ActiveRestClient::Logger.should_receive(:debug).at_least(:once).with(any_args)
+    expect(ActiveRestClient::Logger).to receive(:debug).with(/ActiveRestClient.*ms\)/)
+    expect(ActiveRestClient::Logger).to receive(:debug).at_least(:once).with(any_args)
     InstrumentationExampleClient.real
   end
 

--- a/spec/lib/lazy_association_loader_spec.rb
+++ b/spec/lib/lazy_association_loader_spec.rb
@@ -96,10 +96,10 @@ describe ActiveRestClient::LazyAssociationLoader do
   it "should make the request for a URL if it's accessed" do
     method_data = {options:{url:"foo"}}
     request = double("Request").as_null_object
-    request.stub(:method).and_return(method_data)
-    request.should_receive(:object).with(any_args).and_return(Array.new)
-    request.should_receive(:call).with(any_args).and_return("")
-    ActiveRestClient::Request.should_receive(:new).with(any_args).and_return(request)
+    allow(request).to receive(:method).and_return(method_data)
+    expect(request).to receive(:object).with(any_args).and_return(Array.new)
+    expect(request).to receive(:call).with(any_args).and_return("")
+    expect(ActiveRestClient::Request).to receive(:new).with(any_args).and_return(request)
     loader = ActiveRestClient::LazyAssociationLoader.new(:person, url1, request)
     loader.length
   end
@@ -107,14 +107,14 @@ describe ActiveRestClient::LazyAssociationLoader do
   it "should proxy methods to the underlying object if the request has been made" do
     loader = ActiveRestClient::LazyAssociationLoader.new(:person, url1, request)
     object = double("Object")
-    object.should_receive(:length).and_return(1)
+    expect(object).to receive(:length).and_return(1)
     loader.instance_variable_set(:@object, object)
     expect(loader.length).to eq(1)
   end
 
   it "should be able to iterate underlying object if it's an array" do
     loader = ActiveRestClient::LazyAssociationLoader.new(:person, url1, request)
-    ActiveRestClient::Request.any_instance.should_receive(:call).with(any_args).and_return([1,2,3])
+    expect_any_instance_of(ActiveRestClient::Request).to receive(:call).with(any_args).and_return([1,2,3])
     test = []
     loader.each do |item|
       test << item
@@ -124,7 +124,7 @@ describe ActiveRestClient::LazyAssociationLoader do
 
   it "should be able to return the size of the underlying object if it's an array" do
     loader = ActiveRestClient::LazyAssociationLoader.new(:person, url1, request)
-    ActiveRestClient::Request.any_instance.should_receive(:call).with(any_args).and_return([1,2,3])
+    expect_any_instance_of(ActiveRestClient::Request).to receive(:call).with(any_args).and_return([1,2,3])
     expect(loader.size).to eq(3)
   end
 

--- a/spec/lib/lazy_loader_spec.rb
+++ b/spec/lib/lazy_loader_spec.rb
@@ -5,21 +5,21 @@ describe ActiveRestClient::LazyLoader do
   let(:response) { double("Response") }
 
   it "should not #call the passed in request during initialisation" do
-    request.should_not_receive(:call)
+    expect(request).not_to receive(:call)
     ActiveRestClient::LazyLoader.new(request)
   end
 
   it "should #call the passed in request if you check for response to a message" do
-    request.should_receive(:call)
+    expect(request).to receive(:call)
     loader = ActiveRestClient::LazyLoader.new(request)
     loader.respond_to?(:each)
   end
 
   it "should #call the passed in request if you call a method and pass through the method" do
-    request.should_receive(:call).and_return(response)
-    response.should_receive(:valid).and_return(true)
+    expect(request).to receive(:call).and_return(response)
+    expect(response).to receive(:valid).and_return(true)
     loader = ActiveRestClient::LazyLoader.new(request)
-    expect(loader.valid).to be_true
+    expect(loader.valid).to be_truthy
   end
 
 end

--- a/spec/lib/logger_spec.rb
+++ b/spec/lib/logger_spec.rb
@@ -13,10 +13,10 @@ describe ActiveRestClient::Instrumentation do
     end
 
     Rails.logger = double("Logger")
-    Rails.logger.should_receive(:debug)
-    Rails.logger.should_receive(:info)
-    Rails.logger.should_receive(:warn)
-    Rails.logger.should_receive(:error)
+    expect(Rails.logger).to receive(:debug)
+    expect(Rails.logger).to receive(:info)
+    expect(Rails.logger).to receive(:warn)
+    expect(Rails.logger).to receive(:error)
     ActiveRestClient::Logger.debug("Hello world")
     ActiveRestClient::Logger.info("Hello world")
     ActiveRestClient::Logger.warn("Hello world")
@@ -27,28 +27,28 @@ describe ActiveRestClient::Instrumentation do
   it "should write to a logfile if one has been specified" do
     ActiveRestClient::Logger.logfile = "/dev/null"
     file = double('file')
-    File.should_receive(:open).with("/dev/null", "a").and_yield(file)
-    file.should_receive(:<<).with("Hello world")
+    expect(File).to receive(:open).with("/dev/null", "a").and_yield(file)
+    expect(file).to receive(:<<).with("Hello world")
     ActiveRestClient::Logger.debug("Hello world")
 
     file = double('file')
-    File.should_receive(:open).with("/dev/null", "a").and_yield(file)
-    file.should_receive(:<<).with("Hello info")
+    expect(File).to receive(:open).with("/dev/null", "a").and_yield(file)
+    expect(file).to receive(:<<).with("Hello info")
     ActiveRestClient::Logger.info("Hello info")
 
     file = double('file')
-    File.should_receive(:open).with("/dev/null", "a").and_yield(file)
-    file.should_receive(:<<).with("Hello error")
+    expect(File).to receive(:open).with("/dev/null", "a").and_yield(file)
+    expect(file).to receive(:<<).with("Hello error")
     ActiveRestClient::Logger.error("Hello error")
 
     file = double('file')
-    File.should_receive(:open).with("/dev/null", "a").and_yield(file)
-    file.should_receive(:<<).with("Hello warn")
+    expect(File).to receive(:open).with("/dev/null", "a").and_yield(file)
+    expect(file).to receive(:<<).with("Hello warn")
     ActiveRestClient::Logger.warn("Hello warn")
   end
 
   it "should append to its own messages list if neither Rails nor a logfile has been specified" do
-    File.should_not_receive(:open)
+    expect(File).not_to receive(:open)
     ActiveRestClient::Logger.debug("Hello world")
     ActiveRestClient::Logger.info("Hello info")
     ActiveRestClient::Logger.warn("Hello warn")

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -79,43 +79,43 @@ end
 
 describe ActiveRestClient::Base do
   it "allows the URL to be changed" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/getAll?id=1", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/getAll?id=1", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
     ProxyClientExample.all(id:1)
   end
 
   it "allows the URL to be replaced" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/new", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/new", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
     ProxyClientExample.old
   end
 
   it "has access to the GET params and allow them to be changed/removed/added" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/list?age=12&first_name=John", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/list?age=12&first_name=John", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
     ProxyClientExample.list(fname:"John", lname:"Smith")
   end
 
   it "has access to the POST params and allow them to be changed/removed/added" do
-    ActiveRestClient::Connection.any_instance.should_receive(:post).with("/create", {age:12, first_name:"John"}.to_query, instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:post).with("/create", {age:12, first_name:"John"}.to_query, instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
     ProxyClientExample.create(fname:"John", lname:"Smith")
   end
 
   it "has access to raw body content for requests" do
-    ActiveRestClient::Connection.any_instance.should_receive(:put).with("/update", "MY-BODY-CONTENT", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/update", "MY-BODY-CONTENT", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
     ProxyClientExample.update(fname:"John", lname:"Smith")
   end
 
   it "handles DELETE requests" do
-    ActiveRestClient::Connection.any_instance.should_receive(:delete).with("/remove", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:delete).with("/remove", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
     ProxyClientExample.remove
   end
 
   it "can return fake JSON data and have this parsed in the normal way" do
-    ActiveRestClient::Connection.any_instance.should_not_receive(:get).with("/fake", instance_of(Hash))
+    expect_any_instance_of(ActiveRestClient::Connection).not_to receive(:get).with("/fake", instance_of(Hash))
     ret = ProxyClientExample.fake
     expect(ret.id).to eq(1234)
   end
 
   it "can intercept the response and parse the response, alter it and pass it on during the request" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/change-format", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"fname\":\"Billy\"}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/change-format", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"fname\":\"Billy\"}", status:200, headers:{}))
     ret = ProxyClientExample.change_format
     expect(ret.first_name).to eq("Billy")
   end
@@ -128,7 +128,7 @@ describe ActiveRestClient::Base do
   end
 
   it "can continue with the request in the normal way, passing it on to the server" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/not_proxied?id=1", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/not_proxied?id=1", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
     ProxyClientExample.not_proxied(id:1)
   end
 
@@ -140,12 +140,12 @@ describe ActiveRestClient::Base do
         etag:@etag)
 
     cache_store = double("CacheStore")
-    cache_store.stub(:read).with(any_args).and_return(nil)
+    allow(cache_store).to receive(:read).with(any_args).and_return(nil)
     ProxyClientExample.perform_caching true
-    ProxyClientExample.stub(:cache_store).and_return(cache_store)
+    allow(ProxyClientExample).to receive(:cache_store).and_return(cache_store)
     expiry = 10.minutes.from_now.rfc2822
-    ActiveRestClient::Connection.any_instance.should_receive(:put).with("/update", "MY-BODY-CONTENT", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{"Expires" => expiry, "ETag" => "123456"}))
-    ProxyClientExample.cache_store.should_receive(:write) do |key, object, options|
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/update", "MY-BODY-CONTENT", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{"Expires" => expiry, "ETag" => "123456"}))
+    expect(ProxyClientExample.cache_store).to receive(:write) do |key, object, options|
       expect(key).to eq("ProxyClientExample:/update")
       expect(object).to be_an_instance_of(String)
       unmarshalled = Marshal.load(object)
@@ -162,8 +162,8 @@ describe ActiveRestClient::Base do
   end
 
   it "can force the URL from a filter without it being passed through URL replacement" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/hal_test/1", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/this/is/a/test", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/hal_test/1", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/this/is/a/test", instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", status:200, headers:{}))
     expect(ProxyClientExample.hal_test(id:1).test.result).to eq(true)
   end
 

--- a/spec/lib/recording_spec.rb
+++ b/spec/lib/recording_spec.rb
@@ -5,11 +5,11 @@ describe ActiveRestClient::Recording do
     class MyObject1
       include ActiveRestClient::Recording
     end
-    expect(MyObject1.record_response?).to be_false
+    expect(MyObject1.record_response?).to be_falsey
     MyObject1.record_response do
       puts "Hello world"
     end
-    expect(MyObject1.record_response?).to be_true
+    expect(MyObject1.record_response?).to be_truthy
   end
 
   it "remembers a block given to it to later be called back" do

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -56,86 +56,86 @@ describe ActiveRestClient::Request do
       post :save, "/save"
     end
 
-    ActiveRestClient::Request.any_instance.stub(:read_cached_response)
+    allow_any_instance_of(ActiveRestClient::Request).to receive(:read_cached_response)
   end
 
   it "should get an HTTP connection when called" do
     connection = double(ActiveRestClient::Connection).as_null_object
-    ActiveRestClient::ConnectionManager.should_receive(:get_connection).and_return(connection)
-    connection.should_receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
+    expect(ActiveRestClient::ConnectionManager).to receive(:get_connection).and_return(connection)
+    expect(connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
     ExampleClient.all
   end
 
   it "should get an HTTP connection when called and call get on it" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
     ExampleClient.all
   end
 
   it "should get an HTTP connection when called and call delete on it" do
-    ActiveRestClient::Connection.any_instance.should_receive(:delete).with("/remove/1", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:delete).with("/remove/1", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
     ExampleClient.remove(id:1)
   end
 
   it "should work with faraday response objects" do
     response = Faraday::Response.new
-    response.stub(:body).and_return({}.to_json)
-    ActiveRestClient::Connection.any_instance.should_receive(:get).and_return(response)
+    allow(response).to receive(:body).and_return({}.to_json)
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).and_return(response)
     expect { ExampleClient.all }.to_not raise_error
   end
 
   it "should pass through get parameters" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/?debug=true", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/?debug=true", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
     ExampleClient.all debug:true
   end
 
   it "should pass through get parameters, using defaults specified" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/defaults?overwrite=yes&persist=yes", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/defaults?overwrite=yes&persist=yes", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
     ExampleClient.defaults overwrite:"yes"
   end
 
   it "should pass through url parameters" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/1234", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/1234", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
     ExampleClient.find id:1234
   end
 
   it "should accept an integer as the only parameter and use it as id" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/1234", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/1234", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
     ExampleClient.find(1234)
   end
 
   it "should accept a string as the only parameter and use it as id" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/1234", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/1234", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
     ExampleClient.find("1234")
   end
 
   it "should pass through url parameters and get parameters" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/1234?debug=true", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/1234?debug=true", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", headers:{}))
     ExampleClient.find id:1234, debug:true
   end
 
   it "should pass through url parameters and put parameters" do
-    ActiveRestClient::Connection.any_instance.should_receive(:put).with("/put/1234", "debug=true", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/put/1234", "debug=true", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", headers:{}))
     ExampleClient.update id:1234, debug:true
   end
 
   it "should encode the body in a form-encoded format by default" do
-    ActiveRestClient::Connection.any_instance.should_receive(:put).with("/put/1234", "debug=true&test=foo", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/put/1234", "debug=true&test=foo", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", headers:{}))
     ExampleClient.update id:1234, debug:true, test:'foo'
   end
 
   it "should encode the body in a JSON format if specified" do
-    ActiveRestClient::Connection.any_instance.should_receive(:put).with("/put/1234", %q({"debug":true,"test":"foo"}), an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/put/1234", %q({"debug":true,"test":"foo"}), an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", headers:{}))
     ExampleClient.request_body_type :json
     ExampleClient.update id:1234, debug:true, test:'foo'
   end
 
   it "should pass through custom headers" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/headers", hash_including("X-My-Header" => "myvalue")).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/headers", hash_including("X-My-Header" => "myvalue")).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
     ExampleClient.headers
   end
 
   it "should parse JSON to give a nice object" do
-    ActiveRestClient::Connection.any_instance.should_receive(:put).with("/put/1234", "debug=true", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true, \"list\":[1,2,3,{\"test\":true}], \"created_at\":\"2012-03-04T01:02:03Z\", \"child\":{\"grandchild\":{\"test\":true}}}", headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/put/1234", "debug=true", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true, \"list\":[1,2,3,{\"test\":true}], \"created_at\":\"2012-03-04T01:02:03Z\", \"child\":{\"grandchild\":{\"test\":true}}}", headers:{}))
     object = ExampleClient.update id:1234, debug:true
     expect(object.result).to eq(true)
     expect(object.list.first).to eq(1)
@@ -177,13 +177,13 @@ describe ActiveRestClient::Request do
   end
 
   it "should log faked responses" do
-    ActiveRestClient::Logger.stub(:debug)
-    ActiveRestClient::Logger.should_receive(:debug).with {|*args| args.first["Faked response found"]}
+    allow(ActiveRestClient::Logger).to receive(:debug)
+    expect(ActiveRestClient::Logger).to receive(:debug).with(/Faked response found/)
     ExampleClient.fake id:1234, debug:true
   end
 
   it "should parse an array within JSON to be a result iterator" do
-    ActiveRestClient::Connection.any_instance.should_receive(:put).with("/put/1234", "debug=true", an_instance_of(Hash)).and_return(OpenStruct.new(body:"[{\"first_name\":\"Johnny\"}, {\"first_name\":\"Billy\"}]", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/put/1234", "debug=true", an_instance_of(Hash)).and_return(OpenStruct.new(body:"[{\"first_name\":\"Johnny\"}, {\"first_name\":\"Billy\"}]", status:200, headers:{}))
     object = ExampleClient.update id:1234, debug:true
     expect(object).to be_instance_of(ActiveRestClient::ResultIterator)
     expect(object.first.first_name).to eq("Johnny")
@@ -192,21 +192,20 @@ describe ActiveRestClient::Request do
   end
 
   it "should instantiate other classes using has_many when required to do so" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"expenses\":[{\"amount\":1}, {\"amount\":2}]}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"expenses\":[{\"amount\":1}, {\"amount\":2}]}", status:200, headers:{}))
     object = ExampleClient.all
     expect(object.expenses.first).to be_instance_of(ExampleOtherClient)
   end
 
   it "should instantiate other classes using has_many even if nested off the root" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/babies", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"children\":{\"eldest\":[{\"name\":\"Billy\"}]}}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/babies", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"children\":{\"eldest\":[{\"name\":\"Billy\"}]}}", status:200, headers:{}))
     object = ExampleClient.babies
     expect(object.children.eldest.first).to be_instance_of(ExampleOtherClient)
   end
 
   it "should assign new attributes to the existing object if possible" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}))
     object = ExampleClient.new(first_name:"John", should_disappear:true)
@@ -217,13 +216,12 @@ describe ActiveRestClient::Request do
   end
 
   it "should clearly pass through 200 status responses" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:200))
-    ActiveRestClient::Logger.should_receive(:info).with {|*args| args.first[%r{Requesting http://www.example.com/create}]}
-    ActiveRestClient::Logger.should_receive(:debug).at_least(1).times.with {|*args| args.first[/Response received \d+ bytes/] || args.first["Trying to read from cache"]}
+    expect(ActiveRestClient::Logger).to receive(:info).with(%r'Requesting http://www.example.com/create')
+    expect(ActiveRestClient::Logger).to receive(:debug).at_least(1).times.with(%r'(Response received \d+ bytes|Trying to read from cache)')
 
     object = ExampleClient.new(first_name:"John", should_disappear:true)
     object.create
@@ -231,26 +229,24 @@ describe ActiveRestClient::Request do
   end
 
   it "should debug log 200 responses" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:200))
-    ActiveRestClient::Logger.should_receive(:info).with {|*args| args.first[%r{Requesting http://www.example.com/create}]}
-    ActiveRestClient::Logger.should_receive(:debug).at_least(1).times.with {|*args| args.first[/Response received \d+ bytes/] || args.first["Trying to read from cache"]}
+    expect(ActiveRestClient::Logger).to receive(:info).with(%r'Requesting http://www.example.com/create')
+    expect(ActiveRestClient::Logger).to receive(:debug).at_least(1).times.with(%r'(Response received \d+ bytes|Trying to read from cache)')
 
     object = ExampleClient.new(first_name:"John", should_disappear:true)
     object.create
   end
 
   it "should verbose debug the with the right http verb" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:200))
-    ActiveRestClient::Logger.should_receive(:debug).with(/ POST /)
-    ActiveRestClient::Logger.stub(:debug).with(any_args)
+    expect(ActiveRestClient::Logger).to receive(:debug).with(/ POST /)
+    allow(ActiveRestClient::Logger).to receive(:debug).with(any_args)
 
     object = VerboseExampleClient.new(first_name:"John", should_disappear:true)
     object.create
@@ -258,19 +254,18 @@ describe ActiveRestClient::Request do
 
   it "should verbose log if enabled" do
     connection = double(ActiveRestClient::Connection).as_null_object
-    ActiveRestClient::ConnectionManager.should_receive(:get_connection).and_return(connection)
-    connection.should_receive(:get).with("/all", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{"Content-Type" => "application/json", "Connection" => "close"}))
-    ActiveRestClient::Logger.should_receive(:debug).with("ActiveRestClient Verbose Log:")
-    ActiveRestClient::Logger.should_receive(:debug).with(/ >> /).at_least(:twice)
-    ActiveRestClient::Logger.should_receive(:debug).with(/ << /).at_least(:twice)
-    ActiveRestClient::Logger.stub(:debug).with(any_args)
+    expect(ActiveRestClient::ConnectionManager).to receive(:get_connection).and_return(connection)
+    expect(connection).to receive(:get).with("/all", an_instance_of(Hash)).and_return(OpenStruct.new(body:'{"result":true}', headers:{"Content-Type" => "application/json", "Connection" => "close"}))
+    expect(ActiveRestClient::Logger).to receive(:debug).with("ActiveRestClient Verbose Log:")
+    expect(ActiveRestClient::Logger).to receive(:debug).with(/ >> /).at_least(:twice)
+    expect(ActiveRestClient::Logger).to receive(:debug).with(/ << /).at_least(:twice)
+    allow(ActiveRestClient::Logger).to receive(:debug).with(any_args)
     VerboseExampleClient.all
   end
 
   it "should raise an unauthorised exception for 401 errors" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:401))
     object = ExampleClient.new(first_name:"John", should_disappear:true)
@@ -285,9 +280,8 @@ describe ActiveRestClient::Request do
   end
 
   it "should raise a forbidden client exception for 403 errors" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:403))
     object = ExampleClient.new(first_name:"John", should_disappear:true)
@@ -302,9 +296,8 @@ describe ActiveRestClient::Request do
   end
 
   it "should raise a not found client exception for 404 errors" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:404))
     object = ExampleClient.new(first_name:"John", should_disappear:true)
@@ -319,9 +312,8 @@ describe ActiveRestClient::Request do
   end
 
   it "should raise a client exceptions for 4xx errors" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:409))
     object = ExampleClient.new(first_name:"John", should_disappear:true)
@@ -336,9 +328,8 @@ describe ActiveRestClient::Request do
   end
 
   it "should raise a server exception for 5xx errors" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:500))
     object = ExampleClient.new(first_name:"John", should_disappear:true)
@@ -354,9 +345,8 @@ describe ActiveRestClient::Request do
 
   it "should raise a parse exception for invalid JSON returns" do
     error_content = "<h1>500 Server Error</h1>"
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:error_content, headers:{'Content-Type' => 'text/html'}, status:500))
     object = ExampleClient.new(first_name:"John", should_disappear:true)
@@ -372,9 +362,8 @@ describe ActiveRestClient::Request do
 
   it "should raise a bad request exception for 400 response status" do
     error_content = "<h1>400 Bad Request</h1>"
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:error_content, headers:{'Content-Type' => 'text/html'}, status:400))
     object = ExampleClient.new(first_name:"John", should_disappear:true)
@@ -390,9 +379,8 @@ describe ActiveRestClient::Request do
 
   it "should raise response parse exception for 200 response status and non json content type" do
     error_content = "<h1>malformed json</h1>"
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:error_content, headers:{'Content-Type' => 'text/html'}, status:200))
     object = ExampleClient.new(first_name:"John", should_disappear:true)
@@ -407,9 +395,8 @@ describe ActiveRestClient::Request do
   end
 
   it "should not override the attributes of the existing object on error response status" do
-    ActiveRestClient::Connection.
-      any_instance.
-      should_receive(:post).
+    expect_any_instance_of(ActiveRestClient::Connection).
+      to receive(:post).
       with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
       and_return(OpenStruct.new(body:'{"errors": ["validation": "error in validation"]}', headers:{'Content-Type' => 'text/html'}, status:400))
     object = ExampleClient.new(first_name:"John", should_disappear:true)
@@ -446,20 +433,20 @@ describe ActiveRestClient::Request do
   end
 
   it "should send all class mapped methods through _filter_request" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"expenses\":[{\"amount\":1}, {\"amount\":2}]}", status:200, headers:{}))
-    ExampleClient.should_receive(:_filter_request).with(any_args).exactly(2).times
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"expenses\":[{\"amount\":1}, {\"amount\":2}]}", status:200, headers:{}))
+    expect(ExampleClient).to receive(:_filter_request).with(any_args).exactly(2).times
     ExampleClient.all
   end
 
   it "should send all instance mapped methods through _filter_request" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"expenses\":[{\"amount\":1}, {\"amount\":2}]}", status:200, headers:{}))
-    ExampleClient.should_receive(:_filter_request).with(any_args).exactly(2).times
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"expenses\":[{\"amount\":1}, {\"amount\":2}]}", status:200, headers:{}))
+    expect(ExampleClient).to receive(:_filter_request).with(any_args).exactly(2).times
     e = ExampleClient.new
     e.all
   end
 
   it "should change the generated object if an after_filter changes it" do
-    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/change", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"expenses\":[{\"amount\":1}, {\"amount\":2}]}", status:200, headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/change", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"expenses\":[{\"amount\":1}, {\"amount\":2}]}", status:200, headers:{}))
     obj = ExampleClient.change
     expect(obj.test).to eq(1)
   end
@@ -479,9 +466,8 @@ describe ActiveRestClient::Request do
 
     it "should allow requests directly to URLs" do
       ActiveRestClient::ConnectionManager.reset!
-      ActiveRestClient::Connection.
-        any_instance.
-        should_receive(:get).
+      expect_any_instance_of(ActiveRestClient::Connection).
+        to receive(:get).
         with("/some/url", an_instance_of(Hash)).
         and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:200))
       SameServerExampleClient.same_server
@@ -490,14 +476,14 @@ describe ActiveRestClient::Request do
     it "should allow requests directly to URLs even if to different URLs" do
       ActiveRestClient::ConnectionManager.reset!
       connection = double("Connection")
-      connection.
-        should_receive(:get).
+      expect(connection).
+        to receive(:get).
         with("/some/url", an_instance_of(Hash)).
         and_return(OpenStruct.new(body:"{}", headers:{}, status:304))
-      connection.
-        stub(:base_url).
+      allow(connection).
+        to receive(:base_url).
         and_return("http://other.example.com")
-      ActiveRestClient::ConnectionManager.should_receive(:find_connection_for_url).with(OtherServerExampleClient::URL).and_return(connection)
+      expect(ActiveRestClient::ConnectionManager).to receive(:find_connection_for_url).with(OtherServerExampleClient::URL).and_return(connection)
       OtherServerExampleClient.other_server
     end
 
@@ -505,9 +491,9 @@ describe ActiveRestClient::Request do
       ActiveRestClient::ConnectionManager.reset!
       connection = double("Connection")
       allow(connection).to receive(:base_url).and_return("http://www.example.com")
-      ActiveRestClient::ConnectionManager.should_receive(:get_connection).with("http://www.example.com").and_return(connection)
-      connection.
-        should_receive(:get).
+      expect(ActiveRestClient::ConnectionManager).to receive(:get_connection).with("http://www.example.com").and_return(connection)
+      expect(connection).
+        to receive(:get).
         with("/v1/people", an_instance_of(Hash)).
         and_return(OpenStruct.new(body:"{\"first_name\":\"John\", \"id\":1234}", headers:{}, status:200))
       @obj = SameServerExampleClient._request('/people')
@@ -519,7 +505,7 @@ describe ActiveRestClient::Request do
     let(:hal) { ExampleClient.hal }
 
     it "should request a HAL response or plain JSON" do
-      ActiveRestClient::Connection.any_instance.should_receive(:get).with("/headers", hash_including("Accept" => "application/hal+json, application/json;q=0.5")).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/headers", hash_including("Accept" => "application/hal+json, application/json;q=0.5")).and_return(OpenStruct.new(body:'{"result":true}', headers:{}))
       ExampleClient.headers
     end
 
@@ -536,17 +522,17 @@ describe ActiveRestClient::Request do
       fake_object = RequestFakeObject.new
       request = ActiveRestClient::Request.new(method, fake_object, {})
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => "application/hal+json"}))
-      expect(request.hal_response?).to be_true
+      expect(request.hal_response?).to be_truthy
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => "application/json"}))
-      expect(request.hal_response?).to be_true
+      expect(request.hal_response?).to be_truthy
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => "text/plain"}))
-      expect(request.hal_response?).to be_false
+      expect(request.hal_response?).to be_falsey
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => ["text/plain", "application/hal+json"]}))
-      expect(request.hal_response?).to be_true
+      expect(request.hal_response?).to be_truthy
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => ["text/plain", "application/json"]}))
-      expect(request.hal_response?).to be_true
+      expect(request.hal_response?).to be_truthy
       request.instance_variable_set(:@response, OpenStruct.new(headers:{"Content-Type" => ["text/plain"]}))
-      expect(request.hal_response?).to be_false
+      expect(request.hal_response?).to be_falsey
     end
 
     it "should map _links in to the normal attributes" do
@@ -579,7 +565,7 @@ describe ActiveRestClient::Request do
   end
 
   it "replaces the body completely in a filter" do
-    ActiveRestClient::Connection.any_instance.should_receive(:post).with("/save", "{\"id\":1234,\"name\":\"john\"}", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{}", headers:{}))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:post).with("/save", "{\"id\":1234,\"name\":\"john\"}", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{}", headers:{}))
     FilteredBodyExampleClient.save id:1234, name:'john'
   end
 end

--- a/spec/lib/result_iterator_spec.rb
+++ b/spec/lib/result_iterator_spec.rb
@@ -29,9 +29,9 @@ describe ActiveRestClient::ResultIterator do
 
   it "should implement any?" do
     result = ActiveRestClient::ResultIterator.new
-    expect(result.any?).to be_false
+    expect(result.any?).to be_falsey
     result << "a"
-    expect(result.any?).to be_true
+    expect(result.any?).to be_truthy
   end
 
   it "should implement items" do
@@ -64,10 +64,10 @@ describe ActiveRestClient::ResultIterator do
 
   it "should implement empty?" do
     result = ActiveRestClient::ResultIterator.new
-    expect(result.empty?).to be_true
+    expect(result.empty?).to be_truthy
     result << "a"
     result << "z"
-    expect(result.empty?).to be_false
+    expect(result.empty?).to be_falsey
   end
 
   it "should implement direct index access" do
@@ -83,7 +83,7 @@ describe ActiveRestClient::ResultIterator do
     100.times do |n|
       result << n
     end
-    expect(result.shuffle.first == result.shuffle.first && result.shuffle.first == result.shuffle.first).to_not be_true
+    expect(result.shuffle.first == result.shuffle.first && result.shuffle.first == result.shuffle.first).to_not be_truthy
   end
 
   it "can parallelise calls to each item" do

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -106,7 +106,7 @@ describe "ActiveRestClient::Validation" do
       validates :name, presence:true
     end
 
-    ValidationExample3.any_instance.should_receive(:valid?)
+    expect_any_instance_of(ValidationExample3).to receive(:valid?)
     object = ValidationExample3.new
     expect { object.create }.to raise_exception(ActiveRestClient::ValidationFailedException)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,17 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
+
+  config.mock_with :rspec do |mocks|
+    # In RSpec 3, `any_instance` implementation blocks will be yielded the receiving
+    # instance as the first block argument to allow the implementation block to use
+    # the state of the receiver.
+    # In RSpec 2.99, to maintain compatibility with RSpec 3 you need to either set
+    # this config option to `false` OR set this to `true` and update your
+    # `any_instance` implementation blocks to account for the first block argument
+    # being the receiving instance.
+    mocks.yield_receiver_to_any_instance_implementation_blocks = true
+  end
 end
 
 class TestCacheStore


### PR DESCRIPTION
This conversion is done by Transpec 3.0.7 with the following command:
    transpec -f

* 77 conversions
    from: Klass.any_instance.should_receive(:message)
      to: expect_any_instance_of(Klass).to receive(:message)

* 49 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 19 conversions
    from: be_true
      to: be_truthy

* 12 conversions
    from: be_false
      to: be_falsey

* 8 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 5 conversions
    from: Klass.any_instance.should_not_receive(:message)
      to: expect_any_instance_of(Klass).not_to receive(:message)

* 2 conversions
    from: obj.should
      to: expect(obj).to

* 2 conversions
    from: obj.should_not_receive(:message)
      to: expect(obj).not_to receive(:message)

* 1 conversion
    from: Klass.any_instance.stub(:message)
      to: allow_any_instance_of(Klass).to receive(:message)

* 1 conversion
    from: allow_any_instance_of(Klass).to receive(:message) { |arg| }
      to: allow_any_instance_of(Klass).to receive(:message) { |instance, arg| }

* 1 conversion
    from: expect { }.not_to raise_error(SpecificErrorClass)
      to: expect { }.not_to raise_error

* 1 addition
      of: RSpec.configure { |c| c.mock_with :rspec { |m| m.yield_receiver_to_any_instance_implementation_blocks = true } }

For more details: https://github.com/yujinakayama/transpec#supported-conversions