### PR TITLE
Updated the 'Faking calls' example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ There are times when an API hasn't been developed yet, so you want to fake the A
 
 ```ruby
 class Person < ActiveRestClient::Base
-  get :all, '/people', :fake => "[{first_name:"Johnny"}, {first_name:"Bob"}]"
+  get :all, '/people', fake: [{first_name:"Johnny"}, {first_name:"Bob"}]
 end
 ```
 
@@ -457,7 +457,7 @@ You may want to run a proc when faking data (to put information from the paramet
 
 ```ruby
 class Person < ActiveRestClient::Base
-  get :all, '/people', :fake => ->(request) { "{\"result\":#{request.get_params[:id]}}" }
+  get :all, '/people', fake: ->(request) { {result: request.get_params[:id]} }
 end
 ```
 


### PR DESCRIPTION
I was trying the example faking calls and got the following error:
```
> rails c
Frame number: 0/4
[1] pry(main)> People.all
ActiveRestClient::Base Adapter set to be net_http
  ActiveRestClient People#all - Faked response found
  ActiveRestClient People#all - Response received 43 bytes
  ActiveRestClient (4.4ms) People#all
MultiJson::ParseError: 399: unexpected token at '{first_name:"Johnny"}, {first_name:"Bob"}]'
from /Users/kleaver/.rvm/gems/ruby-2.1.0@scratch/gems/json-1.8.2/lib/json/common.rb:155:in `parse'
[2] pry(main)>
```