### PR TITLE
Parsing correctly formatted ISO 8601 dates

### DIFF
--- a/lib/active_rest_client/base.rb
+++ b/lib/active_rest_client/base.rb
@@ -24,6 +24,8 @@ module ActiveRestClient
         attribute_name = attribute_name.to_sym
         if attribute_value.to_s[/\d{4}\-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})/]
           @attributes[attribute_name] = DateTime.parse(attribute_value)
+        elsif attribute_value.to_s =~ /^\d{4}\-\d{2}-\d{2}$/
+          @attributes[attribute_name] = Date.parse(attribute_value)
         else
           @attributes[attribute_name] = attribute_value
         end

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -73,11 +73,18 @@ describe ActiveRestClient::Base do
     expect(values).to eq(["Billy", "United Kingdom"])
   end
 
-  it "should automatically parse ISO 8601 format dates" do
+  it "should automatically parse ISO 8601 format date and time" do
     t = Time.now
     client = EmptyExample.new(:test => t.iso8601)
     expect(client["test"]).to be_an_instance_of(DateTime)
     expect(client["test"].to_s).to eq(t.to_datetime.to_s)
+  end
+
+  it "should automatically parse ISO 8601 format dates" do
+    d = Date.today
+    client = EmptyExample.new(:test => d.iso8601)
+    expect(client["test"]).to be_an_instance_of(Date)
+    expect(client["test"]).to eq(d)
   end
 
   it "should store attributes set using missing method names and mark them as dirty" do


### PR DESCRIPTION
The gem currently parses strings that combine date and time, but not ISO 8601 dates only. This parses them as Date objects.