### PR TITLE
Exposing ETag as an attribute of the parsed response object

### DIFF
--- a/lib/active_rest_client/base.rb
+++ b/lib/active_rest_client/base.rb
@@ -8,6 +8,7 @@ module ActiveRestClient
     include Recording
 
     attr_accessor :_status
+    attr_accessor :_etag
 
     instance_methods.each do |m|
       next unless %w{display errors presence load require hash untrust trust freeze method enable_warnings with_warnings suppress capture silence quietly debugger breakpoint}.map(&:to_sym).include? m

--- a/lib/active_rest_client/request.rb
+++ b/lib/active_rest_client/request.rb
@@ -437,6 +437,7 @@ module ActiveRestClient
       else
         result = new_object(body, @overriden_name)
         result._status = @response.status
+        result._etag = @response.headers['ETag']
         if !object_is_class? && options[:mutable] != false
           @object._copy_from(result)
           result = @object

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -216,6 +216,13 @@ describe ActiveRestClient::Request do
     expect(object.id).to eq(1234)
   end
 
+  it "should expose etag if available" do
+    response = OpenStruct.new(body: "{}", headers: {"ETag" => "123456"}, status: 200)
+    ActiveRestClient::Connection.any_instance.should_receive(:get).with("/123", an_instance_of(Hash)).and_return(response)
+    object = ExampleClient.find(123)
+    expect(object._etag).to eq("123456")
+  end
+
   it "should clearly pass through 200 status responses" do
     ActiveRestClient::Connection.
       any_instance.


### PR DESCRIPTION
I would like to access the ETag value on the parsed objects, so I can use it as part of the cache key for Rails fragment caching. I am not too familiar with this codebase, so let me know if this is not the right approach.