### PR TITLE
Add #Reverse to ResultIterator

### DIFF
--- a/lib/active_rest_client/result_iterator.rb
+++ b/lib/active_rest_client/result_iterator.rb
@@ -26,6 +26,10 @@ module ActiveRestClient
       size == 0
     end
 
+    def reverse
+      @items.reverse
+    end
+
     def each
       @items.each do |el|
         yield el

--- a/lib/active_rest_client/result_iterator.rb
+++ b/lib/active_rest_client/result_iterator.rb
@@ -27,7 +27,7 @@ module ActiveRestClient
     end
 
     def reverse
-      @items.reverse
+      @reversed_items ||= @items.reverse
     end
 
     def each

--- a/spec/lib/result_iterator_spec.rb
+++ b/spec/lib/result_iterator_spec.rb
@@ -70,6 +70,14 @@ describe ActiveRestClient::ResultIterator do
     expect(result.empty?).to be_falsey
   end
 
+  it "should implement reverse" do
+    result = ActiveRestClient::ResultIterator.new
+    result << "a"
+    result << "z"
+    expect(result.reverse.first).to eq("z")
+    expect(result.reverse.last).to eq("a")
+  end
+
   it "should implement direct index access" do
     result = ActiveRestClient::ResultIterator.new
     result << "a"


### PR DESCRIPTION
It's very useful to be able to revert the result.

This also makes it easier to migrate a model from ActiveRecord.