### PR TITLE
Make params accessible

### DIFF
--- a/lib/active_rest_client/request.rb
+++ b/lib/active_rest_client/request.rb
@@ -4,7 +4,7 @@ require "multi_json"
 module ActiveRestClient
 
   class Request
-    attr_accessor :post_params, :get_params, :url, :path, :headers, :method, :object, :body, :forced_url, :original_url
+    attr_accessor :params, :post_params, :get_params, :url, :path, :headers, :method, :object, :body, :forced_url, :original_url
 
     def initialize(method, object, params = {})
       @method                  = method


### PR DESCRIPTION
For instance makes before_request and after_request methods able to access the params list like this

```
class Resource < ActiveRestClient::Base
  before_request :set_custom_headers

  def set_custom_headers(name, request)
    id = request.params[:id]
    request.headers["x-vy-organization"] = id
  end
end
```

Without access to params we had to use a regular expression or string manipulation on the `request.url` to find the id in the url.