### PR TITLE
Add request signing through Api-Auth gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ This will return an array of the named method for each object or the response fr
 
 ### Authentication
 
+#### Basic
+
 You can authenticate with Basic authentication by putting the username and password in to the `base_url` or by setting them within the specific model:
 
 ```ruby
@@ -449,6 +451,17 @@ class Person < ActiveRestClient::Base
   # ...
 end
 ```
+
+#### Api-Auth
+
+Using the [Api-Auth](https://github.com/mgomes/api_auth) integration it is very easy to sign requests. Simply configure Api-Auth one time in your app and all requests will be signed from then on.
+```ruby
+@access_id = '123456'
+@secret_key = 'abcdef'
+ActiveRestClient::Base.api_auth_credentials(@access_id, @secret_key)
+```
+
+For more information on how to generate an access id and secret key please read the [Api-Auth](https://github.com/mgomes/api_auth) documentation.
 
 ### Body Types
 

--- a/active_rest_client.gemspec
+++ b/active_rest_client.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "faraday"
+  spec.add_runtime_dependency "api-auth", ">= 1.3.1"
   spec.add_runtime_dependency "patron", ">= 0.4.9" # 0.4.18 breaks against Curl v0.7.15 but works with webmock
 end

--- a/lib/active_rest_client/configuration.rb
+++ b/lib/active_rest_client/configuration.rb
@@ -6,6 +6,8 @@ module ActiveRestClient
       @@password = nil
       @@request_body_type = :form_encoded
       @lazy_load = false
+      @@api_auth_access_id = nil
+      @@api_auth_secret_key = nil
 
       def base_url(value = nil)
         if value.nil?
@@ -106,6 +108,23 @@ module ActiveRestClient
         value ? @whiny_missing = value : @whiny_missing || false
       end
 
+      def api_auth_credentials(access_id, secret_key)
+        @@api_auth_access_id = access_id
+        @@api_auth_secret_key = secret_key
+      end
+
+      def using_api_auth?
+        !@@api_auth_access_id.nil? && !@@api_auth_secret_key.nil?
+      end
+
+      def api_auth_access_id
+        @@api_auth_access_id
+      end
+
+      def api_auth_secret_key
+        @@api_auth_secret_key
+      end
+
       def verbose!
         @verbose = true
       end
@@ -124,14 +143,16 @@ module ActiveRestClient
       end
 
       def _reset_configuration!
-        @base_url           = nil
-        @@base_url          = nil
-        @request_body_type  = nil
-        @@request_body_type = :form_encoded
-        @whiny_missing      = nil
-        @lazy_load          = false
-        @faraday_config     = default_faraday_config
-        @adapter            = :patron
+        @base_url             = nil
+        @@base_url            = nil
+        @request_body_type    = nil
+        @@request_body_type   = :form_encoded
+        @whiny_missing        = nil
+        @lazy_load            = false
+        @faraday_config       = default_faraday_config
+        @adapter              = :patron
+        @@api_auth_access_id  = nil
+        @@api_auth_secret_key = nil
       end
 
       private

--- a/lib/active_rest_client/connection.rb
+++ b/lib/active_rest_client/connection.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'api-auth'
 
 module ActiveRestClient
 
@@ -38,6 +39,7 @@ module ActiveRestClient
       make_safe_request(path) do
         @session.get(path) do |req|
           req.headers = req.headers.merge(headers)
+          sign_request(req)
         end
       end
     end
@@ -47,6 +49,7 @@ module ActiveRestClient
         @session.put(path) do |req|
           req.headers = req.headers.merge(headers)
           req.body = data
+          sign_request(req)
         end
       end
     end
@@ -56,6 +59,7 @@ module ActiveRestClient
         @session.post(path) do |req|
           req.headers = req.headers.merge(headers)
           req.body = data
+          sign_request(req)
         end
       end
     end
@@ -64,6 +68,7 @@ module ActiveRestClient
       make_safe_request(path) do
         @session.delete(path) do |req|
           req.headers = req.headers.merge(headers)
+          sign_request(req)
         end
       end
     end
@@ -74,9 +79,16 @@ module ActiveRestClient
       Faraday.new({url: @base_url}, &ActiveRestClient::Base.faraday_config)
     end
 
-
     def full_url(path)
       @session.build_url(path).to_s
+    end
+
+    def sign_request(request)
+      return if !ActiveRestClient::Base.using_api_auth?
+      ApiAuth.sign!(
+        request,
+        ActiveRestClient::Base.api_auth_access_id,
+        ActiveRestClient::Base.api_auth_secret_key)
     end
   end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -108,6 +108,32 @@ describe ActiveRestClient::Configuration do
     expect(LazyLoadingConfigurationExample2.lazy_load?).to be_truthy
   end
 
+  describe 'api auth' do
+    context 'default' do
+      it "should be false using_api_auth?" do
+        expect(ActiveRestClient::Base.using_api_auth?).to be_falsey
+      end
+    end
+
+    context 'setting api auth credentials' do
+      before(:each) do
+        ConfigurationExample.api_auth_credentials('id123', 'secret123')
+      end
+
+      it "should remember setting using_api_auth?" do
+        expect(ConfigurationExample.using_api_auth?).to be_truthy
+      end
+
+      it "should remember setting api_auth_access_id" do
+        expect(ConfigurationExample.api_auth_access_id).to eq('id123')
+      end
+
+      it "should remember setting api_auth_secret_key" do
+        expect(ConfigurationExample.api_auth_secret_key).to eq('secret123')
+      end
+    end
+  end
+
   it "should default to non-verbose loggingg" do
     class VerboseConfigurationExample1
       include ActiveRestClient::Configuration

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -98,6 +98,37 @@ describe ActiveRestClient::Connection do
     end
   end
 
+  context 'with api auth signing requests' do
+    before(:each) do
+      ActiveRestClient::Base.api_auth_credentials('id123', 'secret123')
+
+      @default_headers = {'Date' => 'Sat, 14 Mar 2015 15:13:24 GMT'}
+
+      ActiveRestClient::Base.faraday_config do |faraday|
+        faraday.adapter ActiveRestClient::Base.adapter
+        faraday.headers.update(@default_headers)
+      end
+      @connection.reconnect
+    end
+
+    it 'should have an Authorization header' do
+      stub_request(:get, "www.example.com/foo")
+        .with(:headers => @default_headers)
+        .to_return(body: "{result:true}")
+      result = @connection.get("/foo")
+      expect(result.env.request_headers['Authorization']).to eq("APIAuth id123:PMWBThkB8vKbvUccHvoqu9G3eVk=")
+    end
+
+    it 'should have an Content-MD5 header' do
+      stub_request(:put, "www.example.com/foo").
+        with(body: "body", :headers => @default_headers).
+        to_return(body: "{result:true}")
+
+      result = @connection.put("/foo", "body")
+      expect(result.env.request_headers['Content-MD5']).to eq("hBotaJrYa9FhFEdFPCLG/A==")
+    end
+  end
+
   it "should retry once in the event of a connection failed" do
     stub_request(:get, "www.example.com/foo").to_raise(Faraday::Error::ConnectionFailed.new("Foo"))
     expect { @connection.get("/foo") }.to raise_error(ActiveRestClient::ConnectionFailedException)


### PR DESCRIPTION
Api-Auth is a popular gem for signing and authorizing requests.
ActiveResource an alternative Ruby rest client offers an integration with ApiAuth and it probably the only thing that it offers that ActiveRestClient does not. 

Here is an excerpt from the changes I am making to the docs (gives an example of how to configure)
>Using the Api-Auth integration it is very easy to sign requests. Simply configure Api-Auth one time in your app and all requests will be signed from then on.
```ruby
@access_id = '123456'
@secret_key = 'abcdef'
ActiveRestClient::Base.api_auth_credentials(@access_id, @secret_key)
```

Also if we are able to have this merged I can definitely submit a pull request to Api-Auth to have ActiveRestClient added to their documentation as a support integration.

