### PR TITLE
Support array parameter types

### DIFF
--- a/lib/active_rest_client/request.rb
+++ b/lib/active_rest_client/request.rb
@@ -202,14 +202,13 @@ module ActiveRestClient
 
     def append_get_parameters
       if @get_params.any?
-        params = @get_params.map {|k,v| "#{k}=#{CGI.escape(v.to_s)}"}
-        @url += "?" + params.sort * "&"
+        @url += "?" + @get_params.to_query
       end
     end
 
     def prepare_request_body(params = nil)
       if request_body_type == :form_encoded
-        @body ||= (params || @post_params || {}).map {|k,v| "#{k}=#{CGI.escape(v.to_s)}"}.sort * "&"
+        @body ||= (params || @post_params || {}).to_query
         headers["Content-Type"] ||= "application/x-www-form-urlencoded"
       elsif request_body_type == :json
         @body ||= (params || @post_params || {}).to_json

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -137,6 +137,11 @@ describe ActiveRestClient::Request do
     ExampleClient.update id:1234, debug:true
   end
 
+  it "should pass through 'array type' get parameters" do
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/?include%5B%5D=your&include%5B%5D=friends", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", headers:{}))
+    ExampleClient.all :include => [:your,:friends]
+  end
+
   it "should encode the body in a form-encoded format by default" do
     expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/put/1234", "debug=true&test=foo", an_instance_of(Hash)).and_return(OpenStruct.new(body:"{\"result\":true}", headers:{}))
     ExampleClient.update id:1234, debug:true, test:'foo'


### PR DESCRIPTION
Properly creates the parameter strings using ruby’s built in
`.to_query` method. This also happens to add support for the missing
‘array’ parameter type.

Also has the benefit of simplifying the code around parameter
serialization.