### PR TITLE
Make Api-Auth dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,8 +454,11 @@ end
 
 #### Api-Auth
 
-Using the [Api-Auth](https://github.com/mgomes/api_auth) integration it is very easy to sign requests. Simply configure Api-Auth one time in your app and all requests will be signed from then on.
+Using the [Api-Auth](https://github.com/mgomes/api_auth) integration it is very easy to sign requests. Include the Api-Auth gem in your Gemfile and in then add it to your application. Then simply configure Api-Auth one time in your app and all requests will be signed from then on.
+
 ```ruby
+require 'api-auth'
+
 @access_id = '123456'
 @secret_key = 'abcdef'
 ActiveRestClient::Base.api_auth_credentials(@access_id, @secret_key)

--- a/active_rest_client.gemspec
+++ b/active_rest_client.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency 'terminal-notifier-guard'
   spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency "api-auth", ">= 1.3.1"
 
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "faraday"
-  spec.add_runtime_dependency "api-auth", ">= 1.3.1"
   spec.add_runtime_dependency "patron", ">= 0.4.9" # 0.4.18 breaks against Curl v0.7.15 but works with webmock
 end

--- a/lib/active_rest_client/base.rb
+++ b/lib/active_rest_client/base.rb
@@ -181,4 +181,5 @@ module ActiveRestClient
 
   class NoAttributeException < StandardError ; end
   class ValidationFailedException < StandardError ; end
+  class MissingOptionalLibraryError < StandardError ; end
 end

--- a/lib/active_rest_client/configuration.rb
+++ b/lib/active_rest_client/configuration.rb
@@ -109,6 +109,12 @@ module ActiveRestClient
       end
 
       def api_auth_credentials(access_id, secret_key)
+        begin
+          require 'api-auth'
+        rescue LoadError
+          raise MissingOptionalLibraryError.new("You must include the gem 'api-auth' in your Gemfile to set api-auth credentials.")
+        end
+
         @@api_auth_access_id = access_id
         @@api_auth_secret_key = secret_key
       end

--- a/lib/active_rest_client/connection.rb
+++ b/lib/active_rest_client/connection.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'api-auth'
 
 module ActiveRestClient
 


### PR DESCRIPTION
Gives a nice error message reminding you to require the api-auth gem if you forget to.