### PR TITLE
Invalid expires header handling

### DIFF
--- a/lib/active_rest_client/caching.rb
+++ b/lib/active_rest_client/caching.rb
@@ -66,7 +66,13 @@ module ActiveRestClient
           ActiveRestClient::Logger.debug "  \033[1;4;32m#{ActiveRestClient::NAME}\033[0m #{key} - Writing to cache"
           cached_response = CachedResponse.new(status:response.status, result:result)
           cached_response.etag = response.headers[:etag] if response.headers[:etag]
-          cached_response.expires = Time.parse(response.headers[:expires]) if response.headers[:expires]
+          if response.headers[:expires]
+            cached_response.expires = begin
+                                        Time.parse(response.headers[:expires]) 
+                                      rescue ArgumentError
+                                        1.day.ago.to_time
+                                      end
+          end
           cache_store.write(key, Marshal.dump(cached_response), {})
         end
       end


### PR DESCRIPTION
> HTTP/1.1 clients and caches MUST treat other invalid date formats, especially including the value "0", as in the past (i.e., "already expired").
- http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html