### PR TITLE
Parse DateTime objects with millisecond precision + enhanced regex

### DIFF
--- a/lib/active_rest_client/base.rb
+++ b/lib/active_rest_client/base.rb
@@ -24,10 +24,10 @@ module ActiveRestClient
 
       attrs.each do |attribute_name, attribute_value|
         attribute_name = attribute_name.to_sym
-        if attribute_value.to_s[/\d{4}\-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})/]
-          @attributes[attribute_name] = DateTime.parse(attribute_value)
-        elsif attribute_value.to_s =~ /^\d{4}\-\d{2}-\d{2}$/
+        if attribute_value.to_s[/^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6]))))$/]
           @attributes[attribute_name] = Date.parse(attribute_value)
+        elsif attribute_value.to_s[/^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/]
+          @attributes[attribute_name] = DateTime.parse(attribute_value)
         else
           @attributes[attribute_name] = attribute_value
         end

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -80,6 +80,13 @@ describe ActiveRestClient::Base do
     expect(client["test"].to_s).to eq(t.to_datetime.to_s)
   end
 
+  it "should automatically parse ISO 8601 format date and time with milliseconds" do
+    t = Time.now
+    client = EmptyExample.new(:test => t.iso8601(3))
+    expect(client["test"]).to be_an_instance_of(DateTime)
+    expect(client["test"].to_s).to eq(t.to_datetime.to_s)
+  end
+
   it "should automatically parse ISO 8601 format dates" do
     d = Date.today
     client = EmptyExample.new(:test => d.iso8601)


### PR DESCRIPTION
Support parsing DateTime objects with millisecond precision ([default in Rails 4.1](http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#json-representation-of-time-objects)). Also enhance Date and DateTime parsing to support valid dates (regex based on [this SO post](http://stackoverflow.com/a/14322189/2141313)). Support for parsing regular Date object preserved.