### PR TITLE
Adds support for configuring api_auth with different credentials per model

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,13 @@ require 'api-auth'
 ActiveRestClient::Base.api_auth_credentials(@access_id, @secret_key)
 ```
 
+You can also specify different credentials for different models just like configuring base_url
+```ruby
+class Person < ActiveRestClient::Base
+  api_auth_credentials('123456', 'abcdef')
+end
+```
+
 For more information on how to generate an access id and secret key please read the [Api-Auth](https://github.com/mgomes/api_auth) documentation.
 
 ### Body Types

--- a/lib/active_rest_client/configuration.rb
+++ b/lib/active_rest_client/configuration.rb
@@ -8,8 +8,8 @@ module ActiveRestClient
       @@password = nil
       @@request_body_type = :form_encoded
       @lazy_load = false
-      @@api_auth_access_id = nil
-      @@api_auth_secret_key = nil
+      @api_auth_access_id = nil
+      @api_auth_secret_key = nil
 
       def base_url(value = nil)
         if value.nil?
@@ -121,20 +121,32 @@ module ActiveRestClient
           raise MissingOptionalLibraryError.new("You must include the gem 'api-auth' in your Gemfile to set api-auth credentials.")
         end
 
-        @@api_auth_access_id = access_id
-        @@api_auth_secret_key = secret_key
+        @api_auth_access_id = access_id
+        @api_auth_secret_key = secret_key
       end
 
       def using_api_auth?
-        !@@api_auth_access_id.nil? && !@@api_auth_secret_key.nil?
+        !self.api_auth_access_id.nil? && !self.api_auth_secret_key.nil?
       end
 
       def api_auth_access_id
-        @@api_auth_access_id
+        if !@api_auth_access_id.nil?
+          return @api_auth_access_id
+        elsif self.superclass.respond_to?(:api_auth_access_id)
+          return self.superclass.api_auth_access_id
+        end
+
+        return nil
       end
 
       def api_auth_secret_key
-        @@api_auth_secret_key
+        if !@api_auth_secret_key.nil?
+          return @api_auth_secret_key
+        elsif self.superclass.respond_to?(:api_auth_secret_key)
+          return self.superclass.api_auth_secret_key
+        end
+
+        return nil
       end
 
       def verbose!
@@ -163,8 +175,8 @@ module ActiveRestClient
         @lazy_load            = false
         @faraday_config       = default_faraday_config
         @adapter              = :patron
-        @@api_auth_access_id  = nil
-        @@api_auth_secret_key = nil
+        @api_auth_access_id   = nil
+        @api_auth_secret_key  = nil
       end
 
       private

--- a/lib/active_rest_client/connection.rb
+++ b/lib/active_rest_client/connection.rb
@@ -34,40 +34,44 @@ module ActiveRestClient
       end
     end
 
-    def get(path, headers={})
+    def get(path, options={})
+      set_defaults(options)
       make_safe_request(path) do
         @session.get(path) do |req|
-          req.headers = req.headers.merge(headers)
-          sign_request(req)
+          req.headers = req.headers.merge(options[:headers])
+          sign_request(req, options[:api_auth])
         end
       end
     end
 
-    def put(path, data, headers={})
+    def put(path, data, options={})
+      set_defaults(options)
       make_safe_request(path) do
         @session.put(path) do |req|
-          req.headers = req.headers.merge(headers)
+          req.headers = req.headers.merge(options[:headers])
           req.body = data
-          sign_request(req)
+          sign_request(req, options[:api_auth])
         end
       end
     end
 
-    def post(path, data, headers={})
+    def post(path, data, options={})
+      set_defaults(options)
       make_safe_request(path) do
         @session.post(path) do |req|
-          req.headers = req.headers.merge(headers)
+          req.headers = req.headers.merge(options[:headers])
           req.body = data
-          sign_request(req)
+          sign_request(req, options[:api_auth])
         end
       end
     end
 
-    def delete(path, headers={})
+    def delete(path, options={})
+      set_defaults(options)
       make_safe_request(path) do
         @session.delete(path) do |req|
-          req.headers = req.headers.merge(headers)
-          sign_request(req)
+          req.headers = req.headers.merge(options[:headers])
+          sign_request(req, options[:api_auth])
         end
       end
     end
@@ -82,12 +86,18 @@ module ActiveRestClient
       @session.build_url(path).to_s
     end
 
-    def sign_request(request)
-      return if !ActiveRestClient::Base.using_api_auth?
+    def set_defaults(options)
+      options[:headers]   ||= {}
+      options[:api_auth]  ||= {}
+      return options
+    end
+
+    def sign_request(request, api_auth)
+      return if api_auth[:api_auth_access_id].nil? || api_auth[:api_auth_secret_key].nil?
       ApiAuth.sign!(
         request,
-        ActiveRestClient::Base.api_auth_access_id,
-        ActiveRestClient::Base.api_auth_secret_key)
+        api_auth[:api_auth_access_id],
+        api_auth[:api_auth_secret_key])
     end
   end
 end

--- a/lib/active_rest_client/request.rb
+++ b/lib/active_rest_client/request.rb
@@ -48,6 +48,30 @@ module ActiveRestClient
       end
     end
 
+    def using_api_auth?
+      if object_is_class?
+        @object.using_api_auth?
+      else
+        @object.class.using_api_auth?
+      end
+    end
+
+    def api_auth_access_id
+      if object_is_class?
+        @object.api_auth_access_id
+      else
+        @object.class.api_auth_access_id
+      end
+    end
+
+    def api_auth_secret_key
+      if object_is_class?
+        @object.api_auth_secret_key
+      else
+        @object.class.api_auth_secret_key
+      end
+    end
+
     def username
       if object_is_class?
         @object.username
@@ -283,15 +307,23 @@ module ActiveRestClient
         ActiveRestClient::Logger.debug "  >> Body:\n#{@body}"
       end
 
+      request_options = {:headers => http_headers}
+      if using_api_auth?
+        request_options[:api_auth] = {
+          :api_auth_access_id => api_auth_access_id,
+          :api_auth_secret_key => api_auth_secret_key
+        }
+      end
+
       case http_method
       when :get
-        response = connection.get(@url, http_headers)
+        response = connection.get(@url, request_options)
       when :put
-        response = connection.put(@url, @body, http_headers)
+        response = connection.put(@url, @body, request_options)
       when :post
-        response = connection.post(@url, @body, http_headers)
+        response = connection.post(@url, @body, request_options)
       when :delete
-        response = connection.delete(@url, http_headers)
+        response = connection.delete(@url, request_options)
       else
         raise InvalidRequestException.new("Invalid method #{http_method}")
       end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -155,6 +155,21 @@ describe ActiveRestClient::Configuration do
       it "should remember setting api_auth_secret_key" do
         expect(ConfigurationExample.api_auth_secret_key).to eq('secret123')
       end
+
+      it "should inherit api_auth_credentials when not set" do
+        class ConfigurationExtension < ConfigurationExample
+        end
+        expect(ConfigurationExtension.api_auth_access_id).to eq('id123')
+        expect(ConfigurationExtension.api_auth_secret_key).to eq('secret123')
+      end
+
+      it "should override inherited api_auth_credentials when set" do
+        class ConfigurationExtension2 < ConfigurationExample
+        end
+        ConfigurationExtension2.api_auth_credentials('id456', 'secret456')
+        expect(ConfigurationExtension2.api_auth_access_id).to eq('id456')
+        expect(ConfigurationExtension2.api_auth_secret_key).to eq('secret456')
+      end
     end
   end
 

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -100,7 +100,15 @@ describe ActiveRestClient::Connection do
 
   context 'with api auth signing requests' do
     before(:each) do
+      # Need to still call this to load the api_auth library so tests work
       ActiveRestClient::Base.api_auth_credentials('id123', 'secret123')
+
+      @options = {
+        :api_auth => {
+          :api_auth_access_id => 'id123',
+          :api_auth_secret_key => 'secret123'
+        }
+      }
 
       @default_headers = {'Date' => 'Sat, 14 Mar 2015 15:13:24 GMT'}
 
@@ -115,7 +123,7 @@ describe ActiveRestClient::Connection do
       stub_request(:get, "www.example.com/foo")
         .with(:headers => @default_headers)
         .to_return(body: "{result:true}")
-      result = @connection.get("/foo")
+      result = @connection.get("/foo", @options)
       expect(result.env.request_headers['Authorization']).to eq("APIAuth id123:PMWBThkB8vKbvUccHvoqu9G3eVk=")
     end
 
@@ -124,7 +132,7 @@ describe ActiveRestClient::Connection do
         with(body: "body", :headers => @default_headers).
         to_return(body: "{result:true}")
 
-      result = @connection.put("/foo", "body")
+      result = @connection.put("/foo", "body", @options)
       expect(result.env.request_headers['Content-MD5']).to eq("hBotaJrYa9FhFEdFPCLG/A==")
     end
   end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -7,6 +7,7 @@ describe ActiveRestClient::Request do
     class ExampleClient < ActiveRestClient::Base
       base_url "http://www.example.com"
       request_body_type :form_encoded
+      api_auth_credentials('id123', 'secret123')
 
       before_request do |name, request|
         if request.method[:name] == :headers
@@ -160,17 +161,28 @@ describe ActiveRestClient::Request do
   end
 
   it "should pass through custom headers" do
-    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/headers", hash_including("X-My-Header" => "myvalue")).and_return(::FaradayResponseMock.new(OpenStruct.new(body:'{"result":true}', response_headers:{})))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:get){ |connection, path, options|
+      expect(path).to eq('/headers')
+      expect(options[:headers]).to include("X-My-Header" => "myvalue")
+    }.and_return(::FaradayResponseMock.new(OpenStruct.new(body:'{"result":true}', response_headers:{})))
     ExampleClient.headers
   end
 
   it "should set request header with content-type for default" do
-    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/headers_default", "", hash_including("Content-Type" => "application/x-www-form-urlencoded")).and_return(::FaradayResponseMock.new(OpenStruct.new(body:'{"result":true}', response_headers:{})))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put){ |connection, path, data, options|
+      expect(path).to eq('/headers_default')
+      expect(data).to eq('')
+      expect(options[:headers]).to include("Content-Type" => "application/x-www-form-urlencoded")
+    }.and_return(::FaradayResponseMock.new(OpenStruct.new(body:'{"result":true}', response_headers:{})))
     ExampleClient.headers_default
   end
 
   it "should set request header with content-type for JSON" do
-    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/headers_json", "{}", hash_including("Content-Type" => "application/json; charset=utf-8")).and_return(::FaradayResponseMock.new(OpenStruct.new(body:'{"result":true}', response_headers:{})))
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put){ |connection, path, data, options|
+      expect(path).to eq('/headers_json')
+      expect(data).to eq('{}')
+      expect(options[:headers]).to include("Content-Type" => "application/json; charset=utf-8")
+    }.and_return(::FaradayResponseMock.new(OpenStruct.new(body:'{"result":true}', response_headers:{})))
     ExampleClient.headers_json
   end
 
@@ -578,7 +590,10 @@ describe ActiveRestClient::Request do
     let(:hal) { ExampleClient.hal }
 
     it "should request a HAL response or plain JSON" do
-      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get).with("/headers", hash_including("Accept" => "application/hal+json, application/json;q=0.5")).and_return(::FaradayResponseMock.new(OpenStruct.new(body:'{"result":true}', response_headers:{})))
+      expect_any_instance_of(ActiveRestClient::Connection).to receive(:get){ |connection, path, options|
+        expect(path).to eq('/headers')
+        expect(options[:headers]).to include("Accept" => "application/hal+json, application/json;q=0.5")
+      }.and_return(::FaradayResponseMock.new(OpenStruct.new(body:'{"result":true}', response_headers:{})))
       ExampleClient.headers
     end
 


### PR DESCRIPTION
This change allows for connecting to multiple different servers that would have different API Auth credentials.

Each model or config class can now define it's own api auth credentials independently.
If a base class specifies credentials all sub classes will inherit them. Any sub class can override the credentials though.
