### PR TITLE
Clarify what "complete" configuration block means

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ ActiveRestClient uses Faraday to allow switching HTTP backends, the default is P
 ActiveRestClient::Base.adapter = :net_http
 ```
 
-If you want more control you can pass a complete configuration block. For available config variables look into the Faraday documentation.
+If you want more control you can pass a **complete** configuration block ("complete" means that the block does not *override* [the default configuration](https://github.com/whichdigital/active-rest-client/blob/5b1953d89e26c02ca74f74464ccb7cd4c9439dcc/lib/active_rest_client/configuration.rb#L184-L201), but rather *replaces* it). For available config variables look into the Faraday documentation.
 
 ```ruby
 ActiveRestClient::Base.faraday_config do |faraday|


### PR DESCRIPTION
This is a documentation update suggestion - I might be the only person dumb enough to run into this error, but it might actually be helpful to someone.

**Motivation:** I ran into the following error when I tried to change the faraday configuration option:

```
NoMethodError: undefined method `[]' for nil:NilClass
from /Users/shu/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/active_rest_client-1.0.9/lib/active_rest_client/request.rb:461:in `is_json_response?'
```

I assumed that calling `faraday_config` would *overwrite* the default options, so I thought it'd keep default options such as `faraday.headers['Accept'] = "application/json"`. But it turned out that it replaces the default options. It took me forever to realize this because [the error was on this line](https://github.com/whichdigital/active-rest-client/blob/5b1953d89e26c02ca74f74464ccb7cd4c9439dcc/lib/active_rest_client/request.rb#L504), which didn't seem to have much to do with the config. I updated the README so that hopefully people won't run into the same issue.