### PR TITLE
Remove the Patron Dependency.

### DIFF
--- a/active_rest_client.gemspec
+++ b/active_rest_client.gemspec
@@ -36,5 +36,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "crack"
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "faraday"
-  spec.add_runtime_dependency "patron", ">= 0.4.9" # 0.4.18 breaks against Curl v0.7.15 but works with webmock
 end

--- a/lib/active_rest_client/configuration.rb
+++ b/lib/active_rest_client/configuration.rb
@@ -91,7 +91,7 @@ module ActiveRestClient
       end
 
       def adapter
-        @adapter ||= :patron
+        @adapter ||= Faraday.default_adapter
       end
 
       def faraday_config(&block)
@@ -174,7 +174,7 @@ module ActiveRestClient
         @whiny_missing        = nil
         @lazy_load            = false
         @faraday_config       = default_faraday_config
-        @adapter              = :patron
+        @adapter              = Faraday.default_adapter
         @api_auth_access_id   = nil
         @api_auth_secret_key  = nil
       end

--- a/lib/active_rest_client/version.rb
+++ b/lib/active_rest_client/version.rb
@@ -1,3 +1,3 @@
 module ActiveRestClient
-  VERSION = "1.1.12"
+  VERSION = "1.2.0"
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -209,7 +209,7 @@ describe ActiveRestClient::Configuration do
     let(:faraday_double){double(:faraday).as_null_object}
 
     it "should use default adapter if no other block set" do
-      expect(faraday_double).to receive(:adapter).with(:patron)
+      expect(faraday_double).to receive(:adapter).with(Faraday.default_adapter)
       ConfigurationExample.faraday_config.call(faraday_double)
     end
 


### PR DESCRIPTION
Patron is not compatible with JRuby, using the default 
Faraday adapter (net/http) makes the gem compatible 
with MRI and JRuby while keeping the option of using 
Patron if you set the adapter manually.