### PR TITLE
Don't raise an exception if Rails.cache is not found

### DIFF
--- a/lib/active_rest_client/caching.rb
+++ b/lib/active_rest_client/caching.rb
@@ -30,7 +30,7 @@ module ActiveRestClient
 
       def cache_store
         rails_cache_store = if Object.const_defined?(:Rails)
-          ::Rails.cache
+          ::Rails.try(:cache)
         else
           nil
         end

--- a/spec/lib/caching_spec.rb
+++ b/spec/lib/caching_spec.rb
@@ -49,6 +49,15 @@ describe ActiveRestClient::Caching do
 
     end
 
+    it "should not error if Rails.cache is not found" do
+      begin
+        class Rails; end
+        expect { ActiveRestClient::Base.cache_store }.not_to raise_error
+      ensure
+        Object.send(:remove_const, :Rails) if defined?(Rails)
+      end
+    end
+
     it "should use a custom cache store if a valid one is manually set" do
       class CachingExampleCacheStore1
         def read(key) ; end


### PR DESCRIPTION
We're using active-rest-client in a Grape app, along with ActionMailer. ActionMailer defines a `Rails` module, which causes `ActiveRestClient::Caching#cache_store` to attempt to call `Rails.cache`, which doesn't exist, and throws an exception. This change fixes that so no exception is thrown.
