### PR TITLE
avoid error when parsing strings with iso dates in them

### DIFF
--- a/lib/active_rest_client/request.rb
+++ b/lib/active_rest_client/request.rb
@@ -427,7 +427,7 @@ module ActiveRestClient
             end
           end
         else
-          if v.to_s[/\d{4}\-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})/]
+          if /\A\d{4}\-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})\z/.match(v.to_s)
             object._attributes[k] = DateTime.parse(v)
           else
             object._attributes[k] = v

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -196,6 +196,14 @@ describe ActiveRestClient::Request do
     expect(object.child.grandchild.test).to eq(true)
   end
 
+  it "should not parse string when dates within it" do
+    t = Time.now
+    result = "this is a string with a date on it #{t.iso8601}"
+    expect_any_instance_of(ActiveRestClient::Connection).to receive(:put).with("/put/1234", "debug=true", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(body:"{\"result\":\"#{result}\"}", response_headers:{})))
+    object = ExampleClient.update id:1234, debug:true
+    expect(object.result.to_s).to eq(result)
+  end
+
   it "should parse JSON and return a nice object for faked responses" do
     object = ExampleClient.fake id:1234, debug:true
     expect(object.result).to eq(true)


### PR DESCRIPTION
Hello!

I found an issue when parsing a JSON response when some field includes a string with a iso8601 date in it (f.e `"hello this a string 2015-12-23T16:43:58+01:00"`) 

The condition `v.to_s[/\d{4}\-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})/]` allows it to continue to the parsing. `DateTime` parsing is "nice" enough to detect this situation and the string gets parsed and converted to the `DateTime` that contains, in my case the parsing was raising a "invalid date" exception because the string also had some weird data. In any case, I don't think we should parse the content in this situation. What do you think?

Hope you like my solution!

Cheers,

Julia